### PR TITLE
Update tests for current code

### DIFF
--- a/unittests/databaseService/test_AssetFileInOut.py
+++ b/unittests/databaseService/test_AssetFileInOut.py
@@ -1,74 +1,53 @@
-import os
 import pandas as pd
-import polars as pl
 from src.common.AssetFileInOut import AssetFileInOut
 from src.common.AssetDataService import AssetDataService
 
-def test_FileInOut_FileExists_true():
-    fileOut = AssetFileInOut("unittests/database")
 
+def create_sample_asset() -> object:
     asset = AssetDataService.defaultInstance()
-    asset.ticker="test"
-    fileOut.saveToFile(asset)
+    asset.ticker = "TEST"
 
-    destPath = os.path.join("unittests", "database", "test.pkl")
-    assert os.path.exists(destPath), "File should exist"
-
-    # After the test, clean up the file
-    if os.path.exists(destPath):
-        os.remove(destPath)
-
-def test_FileInOut_FileLoadedSameMOCKED_true():
-    fileOut = AssetFileInOut("unittests/database")
-
-    asset = AssetDataService.defaultInstance()
-    asset.ticker="test"
-
+    # Minimal shareprice dataframe
     data = {
-    'Date': ['1996-02-01 00:00:00-05:00', '1996-02-02 00:00:00-05:00', '1996-02-05 00:00:00-05:00', 
-             '1996-02-06 00:00:00-05:00', '1996-02-07 00:00:00-05:00'],
-    'Open': [1.236482, 1.226971, 1.236482, 1.217460, 1.217460],
-    'High': [1.236482, 1.236482, 1.236482, 1.236482, 1.236482],
-    'Low': [1.217459, 1.217460, 1.217460, 1.217460, 1.217460],
-    'Close': [1.226971, 1.236482, 1.217460, 1.217460, 1.217460],
-    'AdjClose': [1.126971, 1.136482, 1.117460, 1.117460, 1.017460],
+        "Date": pd.date_range("2020-01-01", periods=5, freq="D").astype(str),
+        "Open": [1, 2, 3, 4, 5],
+        "High": [1, 2, 3, 4, 5],
+        "Low": [1, 2, 3, 4, 5],
+        "Close": [1, 2, 3, 4, 5],
+        "AdjClose": [1, 2, 3, 4, 5],
+        "Volume": [10, 20, 30, 40, 50],
+        "Dividends": [0, 0, 0, 0, 0],
+        "Splits": [0, 0, 0, 0, 0],
     }
+    asset.shareprice = pd.DataFrame(data)
 
-    # Convert the dictionary to a pandas dataframe
-    shareprice = pd.DataFrame(data)
-    shareprice['Date'] = pd.to_datetime(shareprice['Date'])  # Convert the 'Date' column to datetime
+    # Minimal financials dataframes
+    q_cols = AssetDataService.defaultInstance().financials_quarterly.columns
+    a_cols = AssetDataService.defaultInstance().financials_annually.columns
+    asset.financials_quarterly = pd.DataFrame([{c: 0 for c in q_cols}])
+    asset.financials_annually = pd.DataFrame([{c: 0 for c in a_cols}])
+    return asset
 
-    # Create the pandas Series from the given data
-    revenue_data = {
-        'Date': ['2024-06-30', '2024-03-31', '2023-12-31', '2023-09-30', '2023-06-30', '2023-03-31', '2022-12-31'],
-        'Total Revenue': [1534409000.0, 1476863000.0, 1419829000.0, 1388175000.0, 1357936000.0, None, None]
-    }
 
-    # Convert to pandas Series, with Date as the index
-    revenue_series = pd.Series(revenue_data['Total Revenue'], index=pd.to_datetime(revenue_data['Date']), name="Total Revenue")
+def test_save_creates_file(tmp_path):
+    file_io = AssetFileInOut(str(tmp_path))
+    asset = AssetDataService.defaultInstance()
+    asset.ticker = "TEST"
 
-    asset.shareprice = shareprice
-    asset.revenue = revenue_series
+    file_io.saveToFile(asset)
+    dest = tmp_path / "TEST.pkl"
+    assert dest.exists()
 
-    fileOut.saveToFile(asset)
 
-    destPath = os.path.join("unittests", "database", "test.pkl")
-    assert os.path.exists(destPath), "File should exist"
+def test_save_and_load_roundtrip(tmp_path):
+    file_io = AssetFileInOut(str(tmp_path))
+    asset = create_sample_asset()
 
-    loadedAsset = fileOut.loadFromFile("test")
+    file_io.saveToFile(asset)
+    loaded = file_io.loadFromFile("TEST")
 
-    assert asset.ticker == loadedAsset.ticker, "Ticker not same"
-    assert asset.isin == loadedAsset.isin, "isin not same"
-    assert asset.shareprice.equals(loadedAsset.shareprice), "shareprice not same"
-    assert asset.adjClosePrice.equals(loadedAsset.adjClosePrice), "volume not same"
-    assert asset.volume.equals(loadedAsset.volume), "volume not same"
-    assert asset.dividends.equals(loadedAsset.dividends), "dividends not same"
-    assert asset.splits.equals(loadedAsset.splits), "splits not same"
-    assert asset.about == loadedAsset.about, "about not same"
-    assert asset.revenue.equals(loadedAsset.revenue), "revenue not same"
-    assert asset.EBITDA.equals(loadedAsset.EBITDA), "EBITDA not same"
-    assert asset.basicEPS.equals(loadedAsset.basicEPS), "basicEPS not same"
-
-    # After the test, clean up the file
-    if os.path.exists(destPath):
-        os.remove(destPath)
+    pd.testing.assert_frame_equal(asset.shareprice, loaded.shareprice)
+    pd.testing.assert_frame_equal(asset.financials_quarterly, loaded.financials_quarterly)
+    pd.testing.assert_frame_equal(asset.financials_annually, loaded.financials_annually)
+    assert asset.ticker == loaded.ticker
+    assert asset.isin == loaded.isin

--- a/unittests/databaseService/test_OutsourceLoader.py
+++ b/unittests/databaseService/test_OutsourceLoader.py
@@ -1,58 +1,22 @@
-import os
-import pandas as pd
-from pandas.api.types import is_datetime64_any_dtype
-from src.common.AssetData import AssetData
+import pytest
 from src.databaseService.OutsourceLoader import OutsourceLoader
 
-def test_OutsourceLoader_Loadsyfinance():
-    outsourceLoader = OutsourceLoader(outsourceOperator="yfinance")
 
-    asset: AssetData = outsourceLoader.load(ticker="irm")
+def test_invalid_operator():
+    with pytest.raises(NotImplementedError):
+        OutsourceLoader(outsourceOperator="invalid")
 
-    assert asset.ticker == "IRM", "Ticker not same"
-    assert asset.isin == "-", "isin not same"
-    assert type(asset.shareprice) == type(pd.DataFrame(None)), "shareprice not DataFrame"
-    assert type(asset.adjClosePrice) == type(pd.Series(None)), "adjClosePrice not Series"
-    assert type(asset.volume) == type(pd.Series(None)), "volume not Series"
-    assert type(asset.dividends) == type(pd.Series(None)), "dividends not Series"
-    assert type(asset.splits) == type(pd.Series(None)), "splits not Series"
-    assert type(asset.about) == type({}), "about not dict"
-    assert type(asset.revenue) == type(pd.Series(None)), "revenue not Series"
-    assert type(asset.EBITDA) == type(pd.Series(None)), "EBITDA not Series"
-    assert type(asset.basicEPS) == type(pd.Series(None)), "basicEPS not Series"
 
-    assert is_datetime64_any_dtype(asset.shareprice.index), "The dataframe index is not a date."
-    assert is_datetime64_any_dtype(asset.adjClosePrice.index), "The adjClosePrice index is not a date."
-    assert is_datetime64_any_dtype(asset.volume.index), "The volume index is not a date."
-    assert is_datetime64_any_dtype(asset.dividends.index), "The dividends index is not a date."
-    assert is_datetime64_any_dtype(asset.splits.index), "The splits index is not a date."
-    assert is_datetime64_any_dtype(asset.revenue.index), "The revenue index is not a date."
-    assert is_datetime64_any_dtype(asset.EBITDA.index), "The EBITDA index is not a date."
-    assert is_datetime64_any_dtype(asset.basicEPS.index), "The basicEPS index is not a date."
+def test_alpha_vantage_requires_key():
+    with pytest.raises(ValueError):
+        OutsourceLoader(outsourceOperator="alphaVantage")
 
-    asset2: AssetData = outsourceLoader.load(ticker = "CH0011432447")
 
-    assert asset2.ticker == "BSLN.SW", "Ticker not same"
-    assert asset2.isin == "-", "isin not same"
-    assert type(asset2.shareprice) == type(pd.DataFrame(None)), "shareprice not DataFrame"
-    assert type(asset2.adjClosePrice) == type(pd.Series(None)), "volume not Series"
-    assert type(asset2.volume) == type(pd.Series(None)), "volume not Series"
-    assert type(asset2.dividends) == type(pd.Series(None)), "dividends not Series"
-    assert type(asset2.splits) == type(pd.Series(None)), "splits not Series"
-    assert type(asset2.about) == type({}), "about not dict"
-    assert type(asset2.revenue) == type(pd.Series(None)), "revenue not Series"
-    assert type(asset2.EBITDA) == type(pd.Series(None)), "EBITDA not Series"
-    assert type(asset2.basicEPS) == type(pd.Series(None)), "basicEPS not Series"
-
-    asset3: AssetData = outsourceLoader.load(ticker = "goog")
-    assert asset3.isin == "ARDEUT116159", "isin not same"
-
-def test_OutsourceLoader_LoadsUndefined_yfinance():
-    outsourceLoader = OutsourceLoader(outsourceOperator="yfinance")
-    ticker="aaaaaaa"
-    try:
-        asset: AssetData = outsourceLoader.load(ticker=ticker)
-    except:
-        print("Exception was raised as expected")
-        return
-    assert False, "TypeError was not raised"
+def test_request_methods_notimplemented_yfinance():
+    loader = OutsourceLoader(outsourceOperator="yfinance")
+    with pytest.raises(NotImplementedError):
+        loader.request_shareprice("TEST")
+    with pytest.raises(NotImplementedError):
+        loader.request_financials("TEST")
+    with pytest.raises(NotImplementedError):
+        loader.request_company_overview("TEST")

--- a/unittests/stockGroups/test_group_over_20_years.py
+++ b/unittests/stockGroups/test_group_over_20_years.py
@@ -1,36 +1,34 @@
-# tests/test_group_over_20_years.py
-import unittest
-from datetime import datetime, timedelta
 import pandas as pd
+from datetime import timedelta
 from src.common.AssetData import AssetData
 from src.stockGroupsService.GroupOver20Years import GroupOver20Years
 
-class TestGroupOver20Years(unittest.TestCase):
-    def test_check_asset_true(self):
-        """
-        Test that check_asset returns True when the asset has over 20 years of data.
-        """
-        # Create an AssetData object with share price data over 20 years
-        start_date = pd.Timestamp.now(tz='UTC') - timedelta(days=21 * 365.25 + 10)
-        dates = pd.date_range(start=start_date, periods=int(21 * 365.25) + 10)
-        prices = pd.Series(100, index=dates)
-        shareprice = pd.DataFrame({'Price': prices})
-        asset = AssetData(ticker='TEST', shareprice=shareprice)
-        group = GroupOver20Years()
-        self.assertTrue(group.checkAsset(asset))
 
-    def test_check_asset_false(self):
-        """
-        Test that check_asset returns False when the asset has less than 20 years of data.
-        """
-        # Create an AssetData object with share price data less than 20 years
-        start_date = pd.Timestamp.now(tz='UTC') - timedelta(days=19 * 365.25)
-        dates = pd.date_range(start=start_date, periods=int(19 * 365.25))
-        prices = pd.Series(100, index=dates)
-        shareprice = pd.DataFrame({'Price': prices})
-        asset = AssetData(ticker='TEST', shareprice=shareprice)
-        group = GroupOver20Years()
-        self.assertFalse(group.checkAsset(asset))
+def make_shareprice(days: int) -> pd.DataFrame:
+    start = pd.Timestamp.now() - timedelta(days=days)
+    dates = pd.date_range(start=start, periods=days)
+    data = {
+        "Date": dates.astype(str),
+        "Open": 1.0,
+        "High": 1.0,
+        "Low": 1.0,
+        "Close": 1.0,
+        "AdjClose": 1.0,
+        "Volume": 1.0,
+        "Dividends": 0.0,
+        "Splits": 0.0,
+    }
+    return pd.DataFrame(data)
 
-if __name__ == '__main__':
-    unittest.main()
+
+def test_check_asset_true():
+    shareprice = make_shareprice(int(21 * 365.25) + 10)
+    asset = AssetData(ticker="TEST", shareprice=shareprice)
+    assert GroupOver20Years().checkAsset(asset)
+
+
+def test_check_asset_false():
+    # create only a few years of data so requirement is not met
+    shareprice = make_shareprice(int(2 * 365.25))
+    asset = AssetData(ticker="TEST", shareprice=shareprice)
+    assert not GroupOver20Years().checkAsset(asset)


### PR DESCRIPTION
## Summary
- update AssetFileInOut tests to use temp paths and updated data model
- rewrite OutsourceLoader tests for new API
- refresh GroupOver20Years tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879235489288325bdfbd24d9f228e84