### PR TITLE
Add transformer-enhanced LSTM pipeline with Optuna tuning

### DIFF
--- a/notebooks/sandbox_lstm_transformer_optuna.ipynb
+++ b/notebooks/sandbox_lstm_transformer_optuna.ipynb
@@ -1,0 +1,3640 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "0c3b363e",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:44:39,346 - This will print to the notebook's output cell\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+            "  from .autonotebook import tqdm as notebook_tqdm\n"
+          ]
+        }
+      ],
+      "source": [
+        "import sys\n",
+        "import os\n",
+        "\n",
+        "# Get the absolute path to the project directory\n",
+        "project_dir = os.path.abspath(\"..\")\n",
+        "\n",
+        "# Append the project directory to sys.path\n",
+        "if project_dir not in sys.path:\n",
+        "    sys.path.append(project_dir)\n",
+        "    \n",
+        "from src.predictionModule.LoadupSamples import LoadupSamples\n",
+        "from src.predictionModule.MachineModels import MachineModels \n",
+        "\n",
+        "import numpy as np\n",
+        "import datetime\n",
+        "import pandas as pd\n",
+        "import polars as pl\n",
+        "import optuna\n",
+        "\n",
+        "import logging\n",
+        "formatted_date = datetime.datetime.now().strftime(\"%d%b%y_%H%M\").lower()\n",
+        "\n",
+        "logger = logging.getLogger()\n",
+        "logger.setLevel(logging.DEBUG)\n",
+        "handler = logging.StreamHandler(sys.stdout)\n",
+        "formatter = logging.Formatter(fmt=\"%(asctime)s - %(message)s\")\n",
+        "handler.setFormatter(formatter)\n",
+        "if not logger.hasHandlers():\n",
+        "    logger.addHandler(handler)\n",
+        "else:\n",
+        "    logger.handlers[:] = [handler]\n",
+        "\n",
+        "#Output File handler\n",
+        "formatted_str = f\"notebook-lstm-optuna-{formatted_date}\"\n",
+        "file_handler = logging.FileHandler(f\"{formatted_str}.log\", mode=\"w\")\n",
+        "file_handler.setFormatter(formatter)\n",
+        "logger.addHandler(file_handler)\n",
+        "\n",
+        "# Usage\n",
+        "logger.info(\"This will print to the notebook's output cell\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import random\n",
+        "import numpy as np\n",
+        "import torch\n",
+        "random.seed(42)\n",
+        "np.random.seed(42)\n",
+        "torch.manual_seed(42)\n"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "cb954e7d",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "params_default = {\n",
+        "    \"idxAfterPrediction\": 5,\n",
+        "    'timesteps': 90,\n",
+        "    'target_option': 'last',\n",
+        "    \"LoadupSamples_time_scaling_stretch\": True,\n",
+        "    \"LoadupSamples_time_inc_factor\": 10,\n",
+        "    \n",
+        "    \"LSTM_units\": 32,\n",
+        "    \"LSTM_num_layers\": 3,\n",
+        "    \"LSTM_dropout\": 0.001,\n",
+        "    \"LSTM_recurrent_dropout\": 0.001,\n",
+        "    \"LSTM_learning_rate\": 0.001,\n",
+        "    \"LSTM_optimizer\": \"adam\",\n",
+        "    \"LSTM_bidirectional\": True,\n",
+        "    \"LSTM_batch_size\": 2**12,\n",
+        "    \"LSTM_epochs\": 10,\n",
+        "    \"LSTM_l1\": 0.001,\n",
+        "    \"LSTM_l2\": 0.001,\n",
+        "    \"LSTM_inter_dropout\": 0.001,\n",
+        "    \"LSTM_input_gaussian_noise\": 0.001,\n",
+        "    \"LSTM_conv1d\": True,\n",
+        "    \"LSTM_conv1d_kernel_size\": 3,\n",
+        "    \"LSTM_loss\": \"mse\",\n",
+        "    \"LSTM_transformer_before\": False,\n",
+        "    \"LSTM_transformer_after\": False,\n",
+        "    \"LSTM_tf_d_model\": 0,\n",
+        "    \"LSTM_tf_nhead\": 4,\n",
+        "    \"LSTM_tf_num_layers_before\": 1,\n",
+        "    \"LSTM_tf_num_layers_after\": 1,\n",
+        "    \"LSTM_tf_dim_feedforward\": 128,\n",
+        "    \"LSTM_tf_dropout\": 0.1,\n",
+        "    \"LSTM_tf_positional_encoding\": True,\n",
+        "    \"LSTM_tf_pool\": \"last\",\n",
+        "}\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import torch\n",
+        "import numpy as np\n",
+        "from src.predictionModule.MachineModels import MachineModels\n",
+        "X_sm = np.random.rand(2,5,3).astype(np.float32)\n",
+        "y_sm = np.random.rand(2).astype(np.float32)\n",
+        "for before in [False, True]:\n",
+        "    for after in [False, True]:\n",
+        "        params = {**params_default, 'timesteps':5, 'LSTM_epochs':1, 'LSTM_units':4, 'LSTM_transformer_before': before, 'LSTM_transformer_after': after}\n",
+        "        mm = MachineModels(params)\n",
+        "        model,_ = mm.run_LSTM_transformer_torch(X_sm, y_sm, X_sm, y_sm, device='cpu')\n",
+        "        preds = mm.predict_LSTM_transformer_torch(model, X_sm, device='cpu')\n",
+        "        print(before, after, preds.shape)\n"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b05214fc",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "stock_group = \"group_regOHLCV_over5years\"\n",
+        "eval_date = datetime.date(year=2025, month=6, day=13)\n",
+        "split_date = datetime.date(year=2023, month=12, day=31)\n",
+        "\n",
+        "studytime = 60*60*4\n",
+        "studyname = f\"sandbox_lstm_optuna_{formatted_str}\"\n",
+        "n_startup_trials = 15"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ed3912a3",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 13:44:39,658] Using an existing study with name 'sandbox_lstm_optuna_notebook-lstm-optuna-20aug25_1344' instead of creating a new one.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:44:39,658 - Using an existing study with name 'sandbox_lstm_optuna_notebook-lstm-optuna-20aug25_1344' instead of creating a new one.\n",
+            "2025-08-20 13:44:47,257 - Non-finite/too-large values in train y time: 36 samples.\n",
+            "2025-08-20 13:44:47,261 - Removing 36 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:45:16,410 - Epoch 1/2 \u2014 Train RMSE: 0.4457 \u2014 Validation RMSE: 0.3974\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:19<00:19, 19.55s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:45:37,021 - Epoch 2/2 \u2014 Train RMSE: 0.3928 \u2014 Validation RMSE: 0.3730\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:40<00:00, 20.08s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:46:08,398 - Epoch 1/2 \u2014 Train RMSE: 0.3892 \u2014 Validation RMSE: 0.2997\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:21<00:21, 21.03s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:46:29,302 - Epoch 2/2 \u2014 Train RMSE: 0.2697 \u2014 Validation RMSE: 0.2324\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:41<00:00, 20.97s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:46:43,442 - Epoch 1/2 \u2014 Train RMSE: 0.5772 \u2014 Validation RMSE: 0.5559\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:03<00:03,  3.11s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:46:46,506 - Epoch 2/2 \u2014 Train RMSE: 0.5577 \u2014 Validation RMSE: 0.5368\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:06<00:00,  3.09s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:46:47,145 - Trial 1 with params: {'idxAfterPrediction': 3, 'timesteps': 70, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 51, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 4.094134065187888e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2021, 'is_single_feature': True}\n",
+            "2025-08-20 13:46:47,147 -   Duration0: 0:00:51.637684\n",
+            "2025-08-20 13:46:47,147 -   Duration1: 0:00:52.949922\n",
+            "2025-08-20 13:46:47,148 -   Duration2: 0:00:06.836928\n",
+            "2025-08-20 13:46:47,148 -   Val RMSE0 adjusted: 0.0073\n",
+            "2025-08-20 13:46:47,149 -   Val RMSE1 adjusted: 0.2324\n",
+            "2025-08-20 13:46:47,149 -   Val RMSE2 adjusted: 0.0105\n",
+            "2025-08-20 13:46:47,149 -   Mean all prediction: 1.0007\n",
+            "2025-08-20 13:46:47,149 -   Mean above prediction: 0.9988\n",
+            "2025-08-20 13:46:47,149 -   Mean below prediction: 1.0000\n",
+            "2025-08-20 13:46:47,153 -   Quantile 0.99 for distance in mask above: 882.7000000000007\n",
+            "2025-08-20 13:46:47,153 -   Quantile 0.99 for distance in mask below: 795.3600000000006\n",
+            "2025-08-20 13:46:47,153 -   Ratio for quantile-distance-to-length above: 0.0013\n",
+            "2025-08-20 13:46:47,153 -   Ratio for quantile-distance-to-length below: 0.0012\n",
+            "2025-08-20 13:46:47,153 -   Score: 0.9996\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 13:46:47,223] Trial 1 finished with value: 0.999598774160287 and parameters: {'year_start': 2021, 'idxAfterPrediction': 3, 'LoadupSamples_time_inc_factor': 51, 'timesteps': 70, 'LSTM_learning_rate': 4.094134065187888e-05, 'is_single_feature': True, 'apply_abs': True, 'q1': 0.14533453101130284, 'q2': 0.9271228328002243}. Best is trial 1 with value: 0.999598774160287.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:46:47,223 - Trial 1 finished with value: 0.999598774160287 and parameters: {'year_start': 2021, 'idxAfterPrediction': 3, 'LoadupSamples_time_inc_factor': 51, 'timesteps': 70, 'LSTM_learning_rate': 4.094134065187888e-05, 'is_single_feature': True, 'apply_abs': True, 'q1': 0.14533453101130284, 'q2': 0.9271228328002243}. Best is trial 1 with value: 0.999598774160287.\n",
+            "2025-08-20 13:46:56,532 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 13:46:56,537 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:47:29,690 - Epoch 1/2 \u2014 Train RMSE: 0.3758 \u2014 Validation RMSE: 0.2989\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:24<00:24, 24.93s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:47:57,100 - Epoch 2/2 \u2014 Train RMSE: 0.3191 \u2014 Validation RMSE: 0.2987\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:52<00:00, 26.17s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:48:34,940 - Epoch 1/2 \u2014 Train RMSE: 0.2708 \u2014 Validation RMSE: 0.2554\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:25<00:25, 25.63s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:49:01,202 - Epoch 2/2 \u2014 Train RMSE: 0.2277 \u2014 Validation RMSE: 0.2605\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:51<00:00, 25.95s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:49:17,208 - Epoch 1/2 \u2014 Train RMSE: 0.4390 \u2014 Validation RMSE: 0.3881\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:03<00:03,  3.24s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:49:20,322 - Epoch 2/2 \u2014 Train RMSE: 0.3797 \u2014 Validation RMSE: 0.3380\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:06<00:00,  3.18s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:49:20,891 - Trial 2 with params: {'idxAfterPrediction': 5, 'timesteps': 55, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 21, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.00015990229834542707, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2020, 'is_single_feature': True}\n",
+            "2025-08-20 13:49:20,892 -   Duration0: 0:01:04.411890\n",
+            "2025-08-20 13:49:20,892 -   Duration1: 0:01:04.651355\n",
+            "2025-08-20 13:49:20,893 -   Duration2: 0:00:06.937125\n",
+            "2025-08-20 13:49:20,893 -   Val RMSE0 adjusted: 0.0142\n",
+            "2025-08-20 13:49:20,893 -   Val RMSE1 adjusted: 0.2554\n",
+            "2025-08-20 13:49:20,894 -   Val RMSE2 adjusted: 0.0161\n",
+            "2025-08-20 13:49:20,895 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 13:49:20,896 -   Mean above prediction: 1.0003\n",
+            "2025-08-20 13:49:20,896 -   Mean below prediction: 1.0031\n",
+            "2025-08-20 13:49:20,898 -   Quantile 0.99 for distance in mask above: 1947.46\n",
+            "2025-08-20 13:49:20,899 -   Quantile 0.99 for distance in mask below: 1234.1600000000071\n",
+            "2025-08-20 13:49:20,899 -   Ratio for quantile-distance-to-length above: 0.0030\n",
+            "2025-08-20 13:49:20,900 -   Ratio for quantile-distance-to-length below: 0.0019\n",
+            "2025-08-20 13:49:20,900 -   Score: 1.0001\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 13:49:20,974] Trial 2 finished with value: 1.0000513534645115 and parameters: {'year_start': 2020, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 21, 'timesteps': 55, 'LSTM_learning_rate': 0.00015990229834542707, 'is_single_feature': True, 'apply_abs': True, 'q1': 0.12103855117106754, 'q2': 0.945303945284043}. Best is trial 2 with value: 1.0000513534645115.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:49:20,974 - Trial 2 finished with value: 1.0000513534645115 and parameters: {'year_start': 2020, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 21, 'timesteps': 55, 'LSTM_learning_rate': 0.00015990229834542707, 'is_single_feature': True, 'apply_abs': True, 'q1': 0.12103855117106754, 'q2': 0.945303945284043}. Best is trial 2 with value: 1.0000513534645115.\n",
+            "2025-08-20 13:49:32,272 - Non-finite/too-large values in train y time: 36 samples.\n",
+            "2025-08-20 13:49:32,279 - Removing 36 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:50:20,972 - Epoch 1/2 \u2014 Train RMSE: 0.4600 \u2014 Validation RMSE: 0.3451\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:33<00:33, 33.18s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:50:53,964 - Epoch 2/2 \u2014 Train RMSE: 0.3568 \u2014 Validation RMSE: 0.3449\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [01:06<00:00, 33.09s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:51:43,054 - Epoch 1/2 \u2014 Train RMSE: 0.3086 \u2014 Validation RMSE: 0.5712\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:32<00:32, 32.91s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:52:16,095 - Epoch 2/2 \u2014 Train RMSE: 0.3826 \u2014 Validation RMSE: 0.5085\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [01:05<00:00, 32.98s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:52:38,602 - Epoch 1/2 \u2014 Train RMSE: 0.4732 \u2014 Validation RMSE: 0.4014\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:06<00:06,  6.29s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:52:44,882 - Epoch 2/2 \u2014 Train RMSE: 0.3765 \u2014 Validation RMSE: 0.3460\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:12<00:00,  6.28s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:52:45,750 - Trial 3 with params: {'idxAfterPrediction': 3, 'timesteps': 90, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 41, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.00016909959828627797, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2019, 'is_single_feature': False}\n",
+            "2025-08-20 13:52:45,750 -   Duration0: 0:01:22.150287\n",
+            "2025-08-20 13:52:45,754 -   Duration1: 0:01:22.215851\n",
+            "2025-08-20 13:52:45,754 -   Duration2: 0:00:13.561002\n",
+            "2025-08-20 13:52:45,754 -   Val RMSE0 adjusted: 0.0084\n",
+            "2025-08-20 13:52:45,754 -   Val RMSE1 adjusted: 0.5085\n",
+            "2025-08-20 13:52:45,754 -   Val RMSE2 adjusted: 0.0084\n",
+            "2025-08-20 13:52:45,754 -   Mean all prediction: 1.0007\n",
+            "2025-08-20 13:52:45,757 -   Mean above prediction: 1.0011\n",
+            "2025-08-20 13:52:45,758 -   Mean below prediction: 0.9984\n",
+            "2025-08-20 13:52:45,759 -   Quantile 0.99 for distance in mask above: 571.5700000000015\n",
+            "2025-08-20 13:52:45,759 -   Quantile 0.99 for distance in mask below: 476.1900000000005\n",
+            "2025-08-20 13:52:45,761 -   Ratio for quantile-distance-to-length above: 0.0009\n",
+            "2025-08-20 13:52:45,761 -   Ratio for quantile-distance-to-length below: 0.0007\n",
+            "2025-08-20 13:52:45,761 -   Score: 1.0004\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 13:52:45,848] Trial 3 finished with value: 1.0003663606527962 and parameters: {'year_start': 2019, 'idxAfterPrediction': 3, 'LoadupSamples_time_inc_factor': 41, 'timesteps': 90, 'LSTM_learning_rate': 0.00016909959828627797, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.1913543108901487, 'q2': 0.922284563065439}. Best is trial 3 with value: 1.0003663606527962.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:52:45,848 - Trial 3 finished with value: 1.0003663606527962 and parameters: {'year_start': 2019, 'idxAfterPrediction': 3, 'LoadupSamples_time_inc_factor': 41, 'timesteps': 90, 'LSTM_learning_rate': 0.00016909959828627797, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.1913543108901487, 'q2': 0.922284563065439}. Best is trial 3 with value: 1.0003663606527962.\n",
+            "2025-08-20 13:52:50,473 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 13:52:50,480 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:53:06,831 - Epoch 1/2 \u2014 Train RMSE: 0.4569 \u2014 Validation RMSE: 0.4013\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.64s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:53:18,626 - Epoch 2/2 \u2014 Train RMSE: 0.4024 \u2014 Validation RMSE: 0.3971\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:23<00:00, 11.71s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:53:36,949 - Epoch 1/2 \u2014 Train RMSE: 0.3054 \u2014 Validation RMSE: 0.2316\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.79s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:53:48,850 - Epoch 2/2 \u2014 Train RMSE: 0.2392 \u2014 Validation RMSE: 0.2324\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:23<00:00, 11.84s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:53:57,198 - Epoch 1/2 \u2014 Train RMSE: 0.8535 \u2014 Validation RMSE: 0.8021\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:01<00:01,  1.30s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:53:58,342 - Epoch 2/2 \u2014 Train RMSE: 0.8048 \u2014 Validation RMSE: 0.7567\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:02<00:00,  1.22s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:53:58,878 - Trial 4 with params: {'idxAfterPrediction': 5, 'timesteps': 70, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 51, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.0002931274437675417, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2023, 'is_single_feature': False}\n",
+            "2025-08-20 13:53:58,879 -   Duration0: 0:00:29.940313\n",
+            "2025-08-20 13:53:58,880 -   Duration1: 0:00:30.768033\n",
+            "2025-08-20 13:53:58,880 -   Duration2: 0:00:02.984398\n",
+            "2025-08-20 13:53:58,881 -   Val RMSE0 adjusted: 0.0078\n",
+            "2025-08-20 13:53:58,881 -   Val RMSE1 adjusted: 0.2316\n",
+            "2025-08-20 13:53:58,881 -   Val RMSE2 adjusted: 0.0148\n",
+            "2025-08-20 13:53:58,881 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 13:53:58,881 -   Mean above prediction: 1.0026\n",
+            "2025-08-20 13:53:58,881 -   Mean below prediction: 0.9981\n",
+            "2025-08-20 13:53:58,881 -   Quantile 0.99 for distance in mask above: 2037.8199999999988\n",
+            "2025-08-20 13:53:58,881 -   Quantile 0.99 for distance in mask below: 1386.1599999999944\n",
+            "2025-08-20 13:53:58,881 -   Ratio for quantile-distance-to-length above: 0.0031\n",
+            "2025-08-20 13:53:58,887 -   Ratio for quantile-distance-to-length below: 0.0021\n",
+            "2025-08-20 13:53:58,888 -   Score: 1.0005\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 13:53:58,920] Trial 4 finished with value: 1.000525533877933 and parameters: {'year_start': 2023, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 51, 'timesteps': 70, 'LSTM_learning_rate': 0.0002931274437675417, 'is_single_feature': False, 'apply_abs': True, 'q1': 0.1062179536746122, 'q2': 0.9555724701808264}. Best is trial 4 with value: 1.000525533877933.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:53:58,920 - Trial 4 finished with value: 1.000525533877933 and parameters: {'year_start': 2023, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 51, 'timesteps': 70, 'LSTM_learning_rate': 0.0002931274437675417, 'is_single_feature': False, 'apply_abs': True, 'q1': 0.1062179536746122, 'q2': 0.9555724701808264}. Best is trial 4 with value: 1.000525533877933.\n",
+            "2025-08-20 13:54:10,498 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 13:54:10,510 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:54:56,181 - Epoch 1/2 \u2014 Train RMSE: 0.4530 \u2014 Validation RMSE: 0.4054\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:33<00:33, 33.23s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:55:27,888 - Epoch 2/2 \u2014 Train RMSE: 0.4123 \u2014 Validation RMSE: 0.4052\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [01:04<00:00, 32.47s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:56:14,658 - Epoch 1/2 \u2014 Train RMSE: 0.3514 \u2014 Validation RMSE: 0.2503\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:31<00:31, 31.27s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:56:45,990 - Epoch 2/2 \u2014 Train RMSE: 0.2291 \u2014 Validation RMSE: 0.2578\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [01:02<00:00, 31.30s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:57:08,434 - Epoch 1/2 \u2014 Train RMSE: 0.5780 \u2014 Validation RMSE: 0.4974\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:05<00:05,  5.85s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:57:14,160 - Epoch 2/2 \u2014 Train RMSE: 0.4689 \u2014 Validation RMSE: 0.4176\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:11<00:00,  5.79s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:57:14,918 - Trial 5 with params: {'idxAfterPrediction': 5, 'timesteps': 70, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 56, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.00014113575883310453, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2019, 'is_single_feature': False}\n",
+            "2025-08-20 13:57:14,918 -   Duration0: 0:01:20.247139\n",
+            "2025-08-20 13:57:14,918 -   Duration1: 0:01:19.219535\n",
+            "2025-08-20 13:57:14,918 -   Duration2: 0:00:12.418631\n",
+            "2025-08-20 13:57:14,918 -   Val RMSE0 adjusted: 0.0072\n",
+            "2025-08-20 13:57:14,918 -   Val RMSE1 adjusted: 0.2503\n",
+            "2025-08-20 13:57:14,918 -   Val RMSE2 adjusted: 0.0075\n",
+            "2025-08-20 13:57:14,918 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 13:57:14,918 -   Mean above prediction: 0.9958\n",
+            "2025-08-20 13:57:14,918 -   Mean below prediction: 0.9991\n",
+            "2025-08-20 13:57:14,927 -   Quantile 0.99 for distance in mask above: 1218.719999999994\n",
+            "2025-08-20 13:57:14,928 -   Quantile 0.99 for distance in mask below: 1364.3399999999992\n",
+            "2025-08-20 13:57:14,930 -   Ratio for quantile-distance-to-length above: 0.0019\n",
+            "2025-08-20 13:57:14,930 -   Ratio for quantile-distance-to-length below: 0.0021\n",
+            "2025-08-20 13:57:14,930 -   Score: 0.9992\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 13:57:15,009] Trial 5 finished with value: 0.9991675277743085 and parameters: {'year_start': 2019, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 56, 'timesteps': 70, 'LSTM_learning_rate': 0.00014113575883310453, 'is_single_feature': False, 'apply_abs': True, 'q1': 0.18846409915202966, 'q2': 0.9635136492873932}. Best is trial 4 with value: 1.000525533877933.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:57:15,009 - Trial 5 finished with value: 0.9991675277743085 and parameters: {'year_start': 2019, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 56, 'timesteps': 70, 'LSTM_learning_rate': 0.00014113575883310453, 'is_single_feature': False, 'apply_abs': True, 'q1': 0.18846409915202966, 'q2': 0.9635136492873932}. Best is trial 4 with value: 1.000525533877933.\n",
+            "2025-08-20 13:57:19,569 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 13:57:19,569 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:57:36,208 - Epoch 1/2 \u2014 Train RMSE: 0.4930 \u2014 Validation RMSE: 0.4239\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.20s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:57:47,642 - Epoch 2/2 \u2014 Train RMSE: 0.4313 \u2014 Validation RMSE: 0.4238\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.32s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:58:05,572 - Epoch 1/2 \u2014 Train RMSE: 0.3311 \u2014 Validation RMSE: 0.5725\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.29s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:58:16,925 - Epoch 2/2 \u2014 Train RMSE: 0.4629 \u2014 Validation RMSE: 0.4151\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.32s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:58:24,188 - Epoch 1/2 \u2014 Train RMSE: 0.6577 \u2014 Validation RMSE: 0.5878\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:01<00:01,  1.17s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:58:25,443 - Epoch 2/2 \u2014 Train RMSE: 0.5620 \u2014 Validation RMSE: 0.4994\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:02<00:00,  1.21s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:58:25,951 - Trial 6 with params: {'idxAfterPrediction': 5, 'timesteps': 85, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 71, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.0009731424265441023, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2023, 'is_single_feature': False}\n",
+            "2025-08-20 13:58:25,951 -   Duration0: 0:00:29.235212\n",
+            "2025-08-20 13:58:25,951 -   Duration1: 0:00:28.779786\n",
+            "2025-08-20 13:58:25,951 -   Duration2: 0:00:02.936865\n",
+            "2025-08-20 13:58:25,951 -   Val RMSE0 adjusted: 0.0060\n",
+            "2025-08-20 13:58:25,951 -   Val RMSE1 adjusted: 0.4151\n",
+            "2025-08-20 13:58:25,951 -   Val RMSE2 adjusted: 0.0070\n",
+            "2025-08-20 13:58:25,955 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 13:58:25,955 -   Mean above prediction: 1.0241\n",
+            "2025-08-20 13:58:25,955 -   Mean below prediction: 1.0032\n",
+            "2025-08-20 13:58:25,958 -   Quantile 0.99 for distance in mask above: 10088.830000000002\n",
+            "2025-08-20 13:58:25,959 -   Quantile 0.99 for distance in mask below: 7898.660000000004\n",
+            "2025-08-20 13:58:25,959 -   Ratio for quantile-distance-to-length above: 0.0153\n",
+            "2025-08-20 13:58:25,959 -   Ratio for quantile-distance-to-length below: 0.0120\n",
+            "2025-08-20 13:58:25,959 -   Score: 1.0048\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 13:58:25,997] Trial 6 finished with value: 1.0047707591863355 and parameters: {'year_start': 2023, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 85, 'LSTM_learning_rate': 0.0009731424265441023, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.10028852415200096, 'q2': 0.9887794257809277}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:58:25,997 - Trial 6 finished with value: 1.0047707591863355 and parameters: {'year_start': 2023, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 85, 'LSTM_learning_rate': 0.0009731424265441023, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.10028852415200096, 'q2': 0.9887794257809277}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 13:58:30,488 - Non-finite/too-large values in train y time: 48 samples.\n",
+            "2025-08-20 13:58:30,489 - Removing 48 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:58:47,751 - Epoch 1/2 \u2014 Train RMSE: 0.6478 \u2014 Validation RMSE: 0.6259\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.44s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:58:59,170 - Epoch 2/2 \u2014 Train RMSE: 0.6385 \u2014 Validation RMSE: 0.6168\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.43s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:59:17,280 - Epoch 1/2 \u2014 Train RMSE: 0.4105 \u2014 Validation RMSE: 0.4003\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.48s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:59:29,630 - Epoch 2/2 \u2014 Train RMSE: 0.4106 \u2014 Validation RMSE: 0.4003\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:23<00:00, 11.91s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:59:39,200 - Epoch 1/2 \u2014 Train RMSE: 0.7454 \u2014 Validation RMSE: 0.7541\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:01<00:01,  1.73s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:59:40,983 - Epoch 2/2 \u2014 Train RMSE: 0.7435 \u2014 Validation RMSE: 0.7522\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:03<00:00,  1.75s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:59:41,518 - Trial 7 with params: {'idxAfterPrediction': 4, 'timesteps': 90, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 71, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 1.0625021009647437e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2023, 'is_single_feature': False}\n",
+            "2025-08-20 13:59:41,518 -   Duration0: 0:00:29.491936\n",
+            "2025-08-20 13:59:41,518 -   Duration1: 0:00:31.697730\n",
+            "2025-08-20 13:59:41,518 -   Duration2: 0:00:04.061079\n",
+            "2025-08-20 13:59:41,518 -   Val RMSE0 adjusted: 0.0087\n",
+            "2025-08-20 13:59:41,518 -   Val RMSE1 adjusted: 0.4003\n",
+            "2025-08-20 13:59:41,522 -   Val RMSE2 adjusted: 0.0106\n",
+            "2025-08-20 13:59:41,522 -   Mean all prediction: 1.0011\n",
+            "2025-08-20 13:59:41,522 -   Mean above prediction: 1.0100\n",
+            "2025-08-20 13:59:41,522 -   Mean below prediction: 1.0050\n",
+            "2025-08-20 13:59:41,522 -   Quantile 0.99 for distance in mask above: 4226.68\n",
+            "2025-08-20 13:59:41,522 -   Quantile 0.99 for distance in mask below: 5785.239999999995\n",
+            "2025-08-20 13:59:41,528 -   Ratio for quantile-distance-to-length above: 0.0064\n",
+            "2025-08-20 13:59:41,528 -   Ratio for quantile-distance-to-length below: 0.0088\n",
+            "2025-08-20 13:59:41,529 -   Score: 1.0025\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 13:59:41,568] Trial 7 finished with value: 1.0024939131038764 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 90, 'LSTM_learning_rate': 1.0625021009647437e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.14334604202863113, 'q2': 0.9848841076310086}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 13:59:41,568 - Trial 7 finished with value: 1.0024939131038764 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 90, 'LSTM_learning_rate': 1.0625021009647437e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.14334604202863113, 'q2': 0.9848841076310086}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 13:59:48,199 - Non-finite/too-large values in train y time: 48 samples.\n",
+            "2025-08-20 13:59:48,204 - Removing 48 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:00:13,550 - Epoch 1/2 \u2014 Train RMSE: 0.4591 \u2014 Validation RMSE: 0.4081\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:17<00:17, 17.50s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:00:30,504 - Epoch 2/2 \u2014 Train RMSE: 0.4212 \u2014 Validation RMSE: 0.4079\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:34<00:00, 17.23s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:00:56,400 - Epoch 1/2 \u2014 Train RMSE: 0.3788 \u2014 Validation RMSE: 0.4782\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.51s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:01:13,049 - Epoch 2/2 \u2014 Train RMSE: 0.4245 \u2014 Validation RMSE: 0.4234\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:33<00:00, 16.58s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:01:23,490 - Epoch 1/2 \u2014 Train RMSE: 0.5792 \u2014 Validation RMSE: 0.5210\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:01<00:01,  1.76s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:01:25,110 - Epoch 2/2 \u2014 Train RMSE: 0.4937 \u2014 Validation RMSE: 0.4515\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:03<00:00,  1.69s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:01:25,622 - Trial 8 with params: {'idxAfterPrediction': 4, 'timesteps': 80, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 66, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.0004696163645926177, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2022, 'is_single_feature': False}\n",
+            "2025-08-20 14:01:25,622 -   Duration0: 0:00:43.750944\n",
+            "2025-08-20 14:01:25,627 -   Duration1: 0:00:41.883167\n",
+            "2025-08-20 14:01:25,627 -   Duration2: 0:00:03.922596\n",
+            "2025-08-20 14:01:25,629 -   Val RMSE0 adjusted: 0.0062\n",
+            "2025-08-20 14:01:25,629 -   Val RMSE1 adjusted: 0.4234\n",
+            "2025-08-20 14:01:25,629 -   Val RMSE2 adjusted: 0.0068\n",
+            "2025-08-20 14:01:25,629 -   Mean all prediction: 1.0011\n",
+            "2025-08-20 14:01:25,632 -   Mean above prediction: 1.0043\n",
+            "2025-08-20 14:01:25,632 -   Mean below prediction: 0.9884\n",
+            "2025-08-20 14:01:25,632 -   Quantile 0.99 for distance in mask above: 6176.520000000003\n",
+            "2025-08-20 14:01:25,634 -   Quantile 0.99 for distance in mask below: 6240.400000000022\n",
+            "2025-08-20 14:01:25,634 -   Ratio for quantile-distance-to-length above: 0.0094\n",
+            "2025-08-20 14:01:25,634 -   Ratio for quantile-distance-to-length below: 0.0095\n",
+            "2025-08-20 14:01:25,634 -   Score: 1.0011\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:01:25,680] Trial 8 finished with value: 1.0010634847115256 and parameters: {'year_start': 2022, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 66, 'timesteps': 80, 'LSTM_learning_rate': 0.0004696163645926177, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.10030104803974317, 'q2': 0.989487898936215}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:01:25,680 - Trial 8 finished with value: 1.0010634847115256 and parameters: {'year_start': 2022, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 66, 'timesteps': 80, 'LSTM_learning_rate': 0.0004696163645926177, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.10030104803974317, 'q2': 0.989487898936215}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:01:31,820 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 14:01:31,830 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:01:52,632 - Epoch 1/2 \u2014 Train RMSE: 0.3851 \u2014 Validation RMSE: 0.3648\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:15<00:15, 15.95s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:02:08,592 - Epoch 2/2 \u2014 Train RMSE: 0.3808 \u2014 Validation RMSE: 0.3637\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:31<00:00, 15.96s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:02:32,676 - Epoch 1/2 \u2014 Train RMSE: 0.3018 \u2014 Validation RMSE: 0.6071\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.07s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:02:48,135 - Epoch 2/2 \u2014 Train RMSE: 0.3714 \u2014 Validation RMSE: 0.5642\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:31<00:00, 15.77s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:02:59,082 - Epoch 1/2 \u2014 Train RMSE: 0.5739 \u2014 Validation RMSE: 0.4230\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:02<00:02,  2.72s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:03:01,797 - Epoch 2/2 \u2014 Train RMSE: 0.3845 \u2014 Validation RMSE: 0.3618\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:05<00:00,  2.72s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:03:02,356 - Trial 9 with params: {'idxAfterPrediction': 5, 'timesteps': 50, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 36, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.0008907044943000611, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2022, 'is_single_feature': True}\n",
+            "2025-08-20 14:03:02,356 -   Duration0: 0:00:39.849643\n",
+            "2025-08-20 14:03:02,357 -   Duration1: 0:00:39.746692\n",
+            "2025-08-20 14:03:02,357 -   Duration2: 0:00:06.000050\n",
+            "2025-08-20 14:03:02,359 -   Val RMSE0 adjusted: 0.0101\n",
+            "2025-08-20 14:03:02,359 -   Val RMSE1 adjusted: 0.5642\n",
+            "2025-08-20 14:03:02,359 -   Val RMSE2 adjusted: 0.0100\n",
+            "2025-08-20 14:03:02,360 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 14:03:02,360 -   Mean above prediction: 0.9996\n",
+            "2025-08-20 14:03:02,360 -   Mean below prediction: 1.0014\n",
+            "2025-08-20 14:03:02,360 -   Quantile 0.99 for distance in mask above: 1869.0\n",
+            "2025-08-20 14:03:02,364 -   Quantile 0.99 for distance in mask below: 1971.5999999999985\n",
+            "2025-08-20 14:03:02,364 -   Ratio for quantile-distance-to-length above: 0.0028\n",
+            "2025-08-20 14:03:02,364 -   Ratio for quantile-distance-to-length below: 0.0030\n",
+            "2025-08-20 14:03:02,364 -   Score: 0.9999\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:03:02,409] Trial 9 finished with value: 0.999912762996894 and parameters: {'year_start': 2022, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 36, 'timesteps': 50, 'LSTM_learning_rate': 0.0008907044943000611, 'is_single_feature': True, 'apply_abs': False, 'q1': 0.16629904386550737, 'q2': 0.9743386243984123}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:03:02,409 - Trial 9 finished with value: 0.999912762996894 and parameters: {'year_start': 2022, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 36, 'timesteps': 50, 'LSTM_learning_rate': 0.0008907044943000611, 'is_single_feature': True, 'apply_abs': False, 'q1': 0.16629904386550737, 'q2': 0.9743386243984123}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:03:10,313 - Non-finite/too-large values in train y time: 48 samples.\n",
+            "2025-08-20 14:03:10,319 - Removing 48 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:03:41,360 - Epoch 1/2 \u2014 Train RMSE: 0.5080 \u2014 Validation RMSE: 0.4636\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:21<00:21, 21.60s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:04:02,585 - Epoch 2/2 \u2014 Train RMSE: 0.4532 \u2014 Validation RMSE: 0.4243\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:42<00:00, 21.42s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:04:35,154 - Epoch 1/2 \u2014 Train RMSE: 0.3997 \u2014 Validation RMSE: 0.3968\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:21<00:21, 21.12s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:04:56,619 - Epoch 2/2 \u2014 Train RMSE: 0.4043 \u2014 Validation RMSE: 0.3970\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:42<00:00, 21.29s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:05:10,349 - Epoch 1/2 \u2014 Train RMSE: 0.6038 \u2014 Validation RMSE: 0.5832\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:02<00:02,  2.68s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:05:13,041 - Epoch 2/2 \u2014 Train RMSE: 0.5914 \u2014 Validation RMSE: 0.5710\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:05<00:00,  2.69s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:05:13,488 - Trial 10 with params: {'idxAfterPrediction': 4, 'timesteps': 80, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 61, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 3.5191854241735876e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2021, 'is_single_feature': False}\n",
+            "2025-08-20 14:05:13,492 -   Duration0: 0:00:54.198939\n",
+            "2025-08-20 14:05:13,492 -   Duration1: 0:00:53.675033\n",
+            "2025-08-20 14:05:13,492 -   Duration2: 0:00:05.869313\n",
+            "2025-08-20 14:05:13,492 -   Val RMSE0 adjusted: 0.0070\n",
+            "2025-08-20 14:05:13,492 -   Val RMSE1 adjusted: 0.3968\n",
+            "2025-08-20 14:05:13,492 -   Val RMSE2 adjusted: 0.0094\n",
+            "2025-08-20 14:05:13,496 -   Mean all prediction: 1.0011\n",
+            "2025-08-20 14:05:13,496 -   Mean above prediction: 1.0036\n",
+            "2025-08-20 14:05:13,496 -   Mean below prediction: 1.0017\n",
+            "2025-08-20 14:05:13,498 -   Quantile 0.99 for distance in mask above: 560.5200000000004\n",
+            "2025-08-20 14:05:13,499 -   Quantile 0.99 for distance in mask below: 624.6800000000003\n",
+            "2025-08-20 14:05:13,500 -   Ratio for quantile-distance-to-length above: 0.0009\n",
+            "2025-08-20 14:05:13,500 -   Ratio for quantile-distance-to-length below: 0.0009\n",
+            "2025-08-20 14:05:13,500 -   Score: 1.0009\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:05:13,554] Trial 10 finished with value: 1.0008863330479507 and parameters: {'year_start': 2021, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 61, 'timesteps': 80, 'LSTM_learning_rate': 3.5191854241735876e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.12881178909439484, 'q2': 0.905380843811877}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:05:13,554 - Trial 10 finished with value: 1.0008863330479507 and parameters: {'year_start': 2021, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 61, 'timesteps': 80, 'LSTM_learning_rate': 3.5191854241735876e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.12881178909439484, 'q2': 0.905380843811877}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:05:19,718 - Non-finite/too-large values in train y time: 48 samples.\n",
+            "2025-08-20 14:05:19,719 - Removing 48 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:05:43,252 - Epoch 1/2 \u2014 Train RMSE: 0.3627 \u2014 Validation RMSE: 0.3316\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.11s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:05:59,378 - Epoch 2/2 \u2014 Train RMSE: 0.3492 \u2014 Validation RMSE: 0.3312\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:32<00:00, 16.12s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:06:24,018 - Epoch 1/2 \u2014 Train RMSE: 0.3541 \u2014 Validation RMSE: 0.5219\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.02s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:06:40,120 - Epoch 2/2 \u2014 Train RMSE: 0.4169 \u2014 Validation RMSE: 0.4425\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:32<00:00, 16.06s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:06:51,493 - Epoch 1/2 \u2014 Train RMSE: 0.5056 \u2014 Validation RMSE: 0.3813\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:02<00:02,  2.76s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:06:54,238 - Epoch 2/2 \u2014 Train RMSE: 0.3541 \u2014 Validation RMSE: 0.3325\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:05<00:00,  2.76s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:06:54,773 - Trial 11 with params: {'idxAfterPrediction': 4, 'timesteps': 80, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 31, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.0006475686702894344, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2022, 'is_single_feature': True}\n",
+            "2025-08-20 14:06:54,773 -   Duration0: 0:00:40.780252\n",
+            "2025-08-20 14:06:54,773 -   Duration1: 0:00:40.721625\n",
+            "2025-08-20 14:06:54,777 -   Duration2: 0:00:06.059972\n",
+            "2025-08-20 14:06:54,777 -   Val RMSE0 adjusted: 0.0107\n",
+            "2025-08-20 14:06:54,778 -   Val RMSE1 adjusted: 0.4425\n",
+            "2025-08-20 14:06:54,778 -   Val RMSE2 adjusted: 0.0107\n",
+            "2025-08-20 14:06:54,780 -   Mean all prediction: 1.0011\n",
+            "2025-08-20 14:06:54,782 -   Mean above prediction: 1.0016\n",
+            "2025-08-20 14:06:54,782 -   Mean below prediction: 1.0002\n",
+            "2025-08-20 14:06:54,782 -   Quantile 0.99 for distance in mask above: 1827.1200000000026\n",
+            "2025-08-20 14:06:54,782 -   Quantile 0.99 for distance in mask below: 1625.3600000000006\n",
+            "2025-08-20 14:06:54,782 -   Ratio for quantile-distance-to-length above: 0.0028\n",
+            "2025-08-20 14:06:54,782 -   Ratio for quantile-distance-to-length below: 0.0025\n",
+            "2025-08-20 14:06:54,782 -   Score: 1.0004\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:06:54,850] Trial 11 finished with value: 1.0004065908868593 and parameters: {'year_start': 2022, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 31, 'timesteps': 80, 'LSTM_learning_rate': 0.0006475686702894344, 'is_single_feature': True, 'apply_abs': False, 'q1': 0.16711209200739882, 'q2': 0.9701207463906258}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:06:54,850 - Trial 11 finished with value: 1.0004065908868593 and parameters: {'year_start': 2022, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 31, 'timesteps': 80, 'LSTM_learning_rate': 0.0006475686702894344, 'is_single_feature': True, 'apply_abs': False, 'q1': 0.16711209200739882, 'q2': 0.9701207463906258}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:06:59,327 - Non-finite/too-large values in train y time: 48 samples.\n",
+            "2025-08-20 14:06:59,328 - Removing 48 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:07:16,839 - Epoch 1/2 \u2014 Train RMSE: 0.6994 \u2014 Validation RMSE: 0.6741\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.75s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:07:28,531 - Epoch 2/2 \u2014 Train RMSE: 0.6837 \u2014 Validation RMSE: 0.6585\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:23<00:00, 11.72s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:07:46,993 - Epoch 1/2 \u2014 Train RMSE: 0.4155 \u2014 Validation RMSE: 0.4056\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.37s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:07:58,548 - Epoch 2/2 \u2014 Train RMSE: 0.4154 \u2014 Validation RMSE: 0.4053\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.46s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:08:06,528 - Epoch 1/2 \u2014 Train RMSE: 0.5664 \u2014 Validation RMSE: 0.5513\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:01<00:01,  1.61s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:08:07,879 - Epoch 2/2 \u2014 Train RMSE: 0.5644 \u2014 Validation RMSE: 0.5493\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:02<00:00,  1.48s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:08:08,342 - Trial 12 with params: {'idxAfterPrediction': 4, 'timesteps': 90, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 71, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 1.484353518954691e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2023, 'is_single_feature': False}\n",
+            "2025-08-20 14:08:08,342 -   Duration0: 0:00:30.509889\n",
+            "2025-08-20 14:08:08,342 -   Duration1: 0:00:29.310026\n",
+            "2025-08-20 14:08:08,342 -   Duration2: 0:00:03.445675\n",
+            "2025-08-20 14:08:08,342 -   Val RMSE0 adjusted: 0.0093\n",
+            "2025-08-20 14:08:08,342 -   Val RMSE1 adjusted: 0.4053\n",
+            "2025-08-20 14:08:08,346 -   Val RMSE2 adjusted: 0.0077\n",
+            "2025-08-20 14:08:08,346 -   Mean all prediction: 1.0011\n",
+            "2025-08-20 14:08:08,348 -   Mean above prediction: 1.0022\n",
+            "2025-08-20 14:08:08,348 -   Mean below prediction: 0.9992\n",
+            "2025-08-20 14:08:08,350 -   Quantile 0.99 for distance in mask above: 4384.049999999961\n",
+            "2025-08-20 14:08:08,350 -   Quantile 0.99 for distance in mask below: 5003.149999999996\n",
+            "2025-08-20 14:08:08,350 -   Ratio for quantile-distance-to-length above: 0.0067\n",
+            "2025-08-20 14:08:08,350 -   Ratio for quantile-distance-to-length below: 0.0076\n",
+            "2025-08-20 14:08:08,350 -   Score: 1.0005\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:08:08,389] Trial 12 finished with value: 1.0005495097758823 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 90, 'LSTM_learning_rate': 1.484353518954691e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.13094818313313933, 'q2': 0.9876199238266934}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:08:08,389 - Trial 12 finished with value: 1.0005495097758823 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 90, 'LSTM_learning_rate': 1.484353518954691e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.13094818313313933, 'q2': 0.9876199238266934}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:08:12,886 - Non-finite/too-large values in train y time: 48 samples.\n",
+            "2025-08-20 14:08:12,888 - Removing 48 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:08:30,334 - Epoch 1/2 \u2014 Train RMSE: 0.6304 \u2014 Validation RMSE: 0.5962\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.61s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:08:41,885 - Epoch 2/2 \u2014 Train RMSE: 0.5951 \u2014 Validation RMSE: 0.5615\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:23<00:00, 11.58s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:08:59,588 - Epoch 1/2 \u2014 Train RMSE: 0.4327 \u2014 Validation RMSE: 0.4157\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.39s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:09:11,090 - Epoch 2/2 \u2014 Train RMSE: 0.4296 \u2014 Validation RMSE: 0.4130\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.45s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:09:19,591 - Epoch 1/2 \u2014 Train RMSE: 0.7197 \u2014 Validation RMSE: 0.7098\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:01<00:01,  1.59s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:09:21,372 - Epoch 2/2 \u2014 Train RMSE: 0.7130 \u2014 Validation RMSE: 0.7030\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:03<00:00,  1.69s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:09:22,036 - Trial 13 with params: {'idxAfterPrediction': 4, 'timesteps': 90, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 71, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 4.8455982480383896e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2023, 'is_single_feature': False}\n",
+            "2025-08-20 14:09:22,036 -   Duration0: 0:00:29.422315\n",
+            "2025-08-20 14:09:22,036 -   Duration1: 0:00:29.823231\n",
+            "2025-08-20 14:09:22,036 -   Duration2: 0:00:04.064444\n",
+            "2025-08-20 14:09:22,038 -   Val RMSE0 adjusted: 0.0079\n",
+            "2025-08-20 14:09:22,038 -   Val RMSE1 adjusted: 0.4130\n",
+            "2025-08-20 14:09:22,039 -   Val RMSE2 adjusted: 0.0099\n",
+            "2025-08-20 14:09:22,040 -   Mean all prediction: 1.0011\n",
+            "2025-08-20 14:09:22,040 -   Mean above prediction: 1.0046\n",
+            "2025-08-20 14:09:22,040 -   Mean below prediction: 0.9960\n",
+            "2025-08-20 14:09:22,042 -   Quantile 0.99 for distance in mask above: 3509.3499999999885\n",
+            "2025-08-20 14:09:22,042 -   Quantile 0.99 for distance in mask below: 1868.3099999999986\n",
+            "2025-08-20 14:09:22,042 -   Ratio for quantile-distance-to-length above: 0.0053\n",
+            "2025-08-20 14:09:22,042 -   Ratio for quantile-distance-to-length below: 0.0028\n",
+            "2025-08-20 14:09:22,042 -   Score: 1.0012\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:09:22,080] Trial 13 finished with value: 1.0011515431942055 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 90, 'LSTM_learning_rate': 4.8455982480383896e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.1478350370984908, 'q2': 0.9792878735857901}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:09:22,080 - Trial 13 finished with value: 1.0011515431942055 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 90, 'LSTM_learning_rate': 4.8455982480383896e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.1478350370984908, 'q2': 0.9792878735857901}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:09:26,582 - Non-finite/too-large values in train y time: 36 samples.\n",
+            "2025-08-20 14:09:26,586 - Removing 36 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:09:43,528 - Epoch 1/2 \u2014 Train RMSE: 0.5380 \u2014 Validation RMSE: 0.5186\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.45s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:09:55,009 - Epoch 2/2 \u2014 Train RMSE: 0.5282 \u2014 Validation RMSE: 0.5094\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.47s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:10:13,097 - Epoch 1/2 \u2014 Train RMSE: 0.4226 \u2014 Validation RMSE: 0.4057\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.67s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:10:24,722 - Epoch 2/2 \u2014 Train RMSE: 0.4219 \u2014 Validation RMSE: 0.4050\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:23<00:00, 11.65s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:10:32,938 - Epoch 1/2 \u2014 Train RMSE: 0.5252 \u2014 Validation RMSE: 0.5297\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:01<00:01,  1.30s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:10:34,285 - Epoch 2/2 \u2014 Train RMSE: 0.5238 \u2014 Validation RMSE: 0.5283\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:02<00:00,  1.32s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:10:34,721 - Trial 14 with params: {'idxAfterPrediction': 3, 'timesteps': 85, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 61, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 1.4346801990996097e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2023, 'is_single_feature': False}\n",
+            "2025-08-20 14:10:34,725 -   Duration0: 0:00:29.310489\n",
+            "2025-08-20 14:10:34,725 -   Duration1: 0:00:30.237273\n",
+            "2025-08-20 14:10:34,725 -   Duration2: 0:00:03.100110\n",
+            "2025-08-20 14:10:34,725 -   Val RMSE0 adjusted: 0.0084\n",
+            "2025-08-20 14:10:34,725 -   Val RMSE1 adjusted: 0.4050\n",
+            "2025-08-20 14:10:34,725 -   Val RMSE2 adjusted: 0.0087\n",
+            "2025-08-20 14:10:34,728 -   Mean all prediction: 1.0007\n",
+            "2025-08-20 14:10:34,728 -   Mean above prediction: 0.9981\n",
+            "2025-08-20 14:10:34,728 -   Mean below prediction: 0.9994\n",
+            "2025-08-20 14:10:34,728 -   Quantile 0.99 for distance in mask above: 1489.6800000000003\n",
+            "2025-08-20 14:10:34,728 -   Quantile 0.99 for distance in mask below: 1598.3400000000001\n",
+            "2025-08-20 14:10:34,728 -   Ratio for quantile-distance-to-length above: 0.0023\n",
+            "2025-08-20 14:10:34,733 -   Ratio for quantile-distance-to-length below: 0.0024\n",
+            "2025-08-20 14:10:34,734 -   Score: 0.9994\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:10:34,769] Trial 14 finished with value: 0.9993815150154128 and parameters: {'year_start': 2023, 'idxAfterPrediction': 3, 'LoadupSamples_time_inc_factor': 61, 'timesteps': 85, 'LSTM_learning_rate': 1.4346801990996097e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.11649273309008532, 'q2': 0.9532176504528628}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:10:34,769 - Trial 14 finished with value: 0.9993815150154128 and parameters: {'year_start': 2023, 'idxAfterPrediction': 3, 'LoadupSamples_time_inc_factor': 61, 'timesteps': 85, 'LSTM_learning_rate': 1.4346801990996097e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.11649273309008532, 'q2': 0.9532176504528628}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:10:40,925 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 14:10:40,930 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:11:03,104 - Epoch 1/2 \u2014 Train RMSE: 0.6379 \u2014 Validation RMSE: 0.5403\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.49s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:11:19,893 - Epoch 2/2 \u2014 Train RMSE: 0.4919 \u2014 Validation RMSE: 0.4383\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:33<00:00, 16.64s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:11:45,318 - Epoch 1/2 \u2014 Train RMSE: 0.4004 \u2014 Validation RMSE: 0.3925\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.60s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:12:01,990 - Epoch 2/2 \u2014 Train RMSE: 0.4086 \u2014 Validation RMSE: 0.3935\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:33<00:00, 16.64s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:12:13,232 - Epoch 1/2 \u2014 Train RMSE: 0.7188 \u2014 Validation RMSE: 0.6877\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:02<00:02,  2.69s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:12:15,619 - Epoch 2/2 \u2014 Train RMSE: 0.6840 \u2014 Validation RMSE: 0.6529\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:05<00:00,  2.54s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:12:16,259 - Trial 15 with params: {'idxAfterPrediction': 5, 'timesteps': 60, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 71, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 8.161897137383075e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2022, 'is_single_feature': False}\n",
+            "2025-08-20 14:12:16,259 -   Duration0: 0:00:42.046685\n",
+            "2025-08-20 14:12:16,259 -   Duration1: 0:00:41.836231\n",
+            "2025-08-20 14:12:16,267 -   Duration2: 0:00:05.753451\n",
+            "2025-08-20 14:12:16,267 -   Val RMSE0 adjusted: 0.0062\n",
+            "2025-08-20 14:12:16,267 -   Val RMSE1 adjusted: 0.3925\n",
+            "2025-08-20 14:12:16,269 -   Val RMSE2 adjusted: 0.0092\n",
+            "2025-08-20 14:12:16,270 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 14:12:16,270 -   Mean above prediction: 1.0085\n",
+            "2025-08-20 14:12:16,270 -   Mean below prediction: 0.9990\n",
+            "2025-08-20 14:12:16,270 -   Quantile 0.99 for distance in mask above: 2883.899999999997\n",
+            "2025-08-20 14:12:16,270 -   Quantile 0.99 for distance in mask below: 2239.799999999999\n",
+            "2025-08-20 14:12:16,274 -   Ratio for quantile-distance-to-length above: 0.0044\n",
+            "2025-08-20 14:12:16,274 -   Ratio for quantile-distance-to-length below: 0.0034\n",
+            "2025-08-20 14:12:16,274 -   Score: 1.0017\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:12:16,312] Trial 15 finished with value: 1.0016891346126093 and parameters: {'year_start': 2022, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 60, 'LSTM_learning_rate': 8.161897137383075e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.16199348615008552, 'q2': 0.9814969726089954}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:12:16,312 - Trial 15 finished with value: 1.0016891346126093 and parameters: {'year_start': 2022, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 60, 'LSTM_learning_rate': 8.161897137383075e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.16199348615008552, 'q2': 0.9814969726089954}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:12:20,832 - Non-finite/too-large values in train y time: 48 samples.\n",
+            "2025-08-20 14:12:20,835 - Removing 48 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:12:37,801 - Epoch 1/2 \u2014 Train RMSE: 0.6448 \u2014 Validation RMSE: 0.6174\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.47s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:12:49,417 - Epoch 2/2 \u2014 Train RMSE: 0.6244 \u2014 Validation RMSE: 0.5973\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:23<00:00, 11.54s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:13:07,254 - Epoch 1/2 \u2014 Train RMSE: 0.4493 \u2014 Validation RMSE: 0.4239\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.25s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:13:18,517 - Epoch 2/2 \u2014 Train RMSE: 0.4454 \u2014 Validation RMSE: 0.4204\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.26s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:13:26,553 - Epoch 1/2 \u2014 Train RMSE: 0.7016 \u2014 Validation RMSE: 0.6837\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:01<00:01,  1.64s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:13:27,942 - Epoch 2/2 \u2014 Train RMSE: 0.6989 \u2014 Validation RMSE: 0.6810\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:03<00:00,  1.52s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:13:28,552 - Trial 16 with params: {'idxAfterPrediction': 4, 'timesteps': 85, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 61, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 2.3197006874962268e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2023, 'is_single_feature': False}\n",
+            "2025-08-20 14:13:28,552 -   Duration0: 0:00:29.652514\n",
+            "2025-08-20 14:13:28,552 -   Duration1: 0:00:28.926289\n",
+            "2025-08-20 14:13:28,552 -   Duration2: 0:00:03.660172\n",
+            "2025-08-20 14:13:28,556 -   Val RMSE0 adjusted: 0.0098\n",
+            "2025-08-20 14:13:28,556 -   Val RMSE1 adjusted: 0.4204\n",
+            "2025-08-20 14:13:28,556 -   Val RMSE2 adjusted: 0.0112\n",
+            "2025-08-20 14:13:28,558 -   Mean all prediction: 1.0011\n",
+            "2025-08-20 14:13:28,558 -   Mean above prediction: 1.0024\n",
+            "2025-08-20 14:13:28,560 -   Mean below prediction: 1.0001\n",
+            "2025-08-20 14:13:28,560 -   Quantile 0.99 for distance in mask above: 2272.119999999997\n",
+            "2025-08-20 14:13:28,560 -   Quantile 0.99 for distance in mask below: 2002.6499999999965\n",
+            "2025-08-20 14:13:28,560 -   Ratio for quantile-distance-to-length above: 0.0035\n",
+            "2025-08-20 14:13:28,560 -   Ratio for quantile-distance-to-length below: 0.0030\n",
+            "2025-08-20 14:13:28,560 -   Score: 1.0006\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:13:28,598] Trial 16 finished with value: 1.0005904612400582 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 61, 'timesteps': 85, 'LSTM_learning_rate': 2.3197006874962268e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.13617781774248558, 'q2': 0.9648228976338067}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:13:28,598 - Trial 16 finished with value: 1.0005904612400582 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 61, 'timesteps': 85, 'LSTM_learning_rate': 2.3197006874962268e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.13617781774248558, 'q2': 0.9648228976338067}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:13:37,996 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 14:13:38,001 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:14:14,901 - Epoch 1/2 \u2014 Train RMSE: 0.4839 \u2014 Validation RMSE: 0.3875\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:26<00:26, 26.18s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:14:41,124 - Epoch 2/2 \u2014 Train RMSE: 0.4027 \u2014 Validation RMSE: 0.3875\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:52<00:00, 26.20s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:15:20,980 - Epoch 1/2 \u2014 Train RMSE: 0.3302 \u2014 Validation RMSE: 0.5565\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:26<00:26, 26.28s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:15:47,148 - Epoch 2/2 \u2014 Train RMSE: 0.3953 \u2014 Validation RMSE: 0.4754\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:52<00:00, 26.22s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:16:03,432 - Epoch 1/2 \u2014 Train RMSE: 0.6656 \u2014 Validation RMSE: 0.5855\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:03<00:03,  3.06s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:16:06,533 - Epoch 2/2 \u2014 Train RMSE: 0.5498 \u2014 Validation RMSE: 0.4772\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:06<00:00,  3.08s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:16:06,951 - Trial 17 with params: {'idxAfterPrediction': 5, 'timesteps': 75, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 46, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.000261536628084908, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2020, 'is_single_feature': False}\n",
+            "2025-08-20 14:16:06,951 -   Duration0: 0:01:05.835980\n",
+            "2025-08-20 14:16:06,951 -   Duration1: 0:01:05.732325\n",
+            "2025-08-20 14:16:06,951 -   Duration2: 0:00:06.620066\n",
+            "2025-08-20 14:16:06,951 -   Val RMSE0 adjusted: 0.0084\n",
+            "2025-08-20 14:16:06,951 -   Val RMSE1 adjusted: 0.4754\n",
+            "2025-08-20 14:16:06,951 -   Val RMSE2 adjusted: 0.0104\n",
+            "2025-08-20 14:16:06,955 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 14:16:06,955 -   Mean above prediction: 0.9973\n",
+            "2025-08-20 14:16:06,955 -   Mean below prediction: 1.0028\n",
+            "2025-08-20 14:16:06,958 -   Quantile 0.99 for distance in mask above: 895.0\n",
+            "2025-08-20 14:16:06,958 -   Quantile 0.99 for distance in mask below: 1233.12\n",
+            "2025-08-20 14:16:06,959 -   Ratio for quantile-distance-to-length above: 0.0014\n",
+            "2025-08-20 14:16:06,959 -   Ratio for quantile-distance-to-length below: 0.0019\n",
+            "2025-08-20 14:16:06,959 -   Score: 0.9995\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:16:07,019] Trial 17 finished with value: 0.9994508232912928 and parameters: {'year_start': 2020, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 46, 'timesteps': 75, 'LSTM_learning_rate': 0.000261536628084908, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.11302830301483416, 'q2': 0.9327821498299868}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:16:07,019 - Trial 17 finished with value: 0.9994508232912928 and parameters: {'year_start': 2020, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 46, 'timesteps': 75, 'LSTM_learning_rate': 0.000261536628084908, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.11302830301483416, 'q2': 0.9327821498299868}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:16:13,469 - Non-finite/too-large values in train y time: 36 samples.\n",
+            "2025-08-20 14:16:13,473 - Removing 36 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:16:37,943 - Epoch 1/2 \u2014 Train RMSE: 0.7730 \u2014 Validation RMSE: 0.7482\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.83s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:16:54,228 - Epoch 2/2 \u2014 Train RMSE: 0.7523 \u2014 Validation RMSE: 0.7275\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:33<00:00, 16.56s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:17:19,602 - Epoch 1/2 \u2014 Train RMSE: 0.4173 \u2014 Validation RMSE: 0.4058\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.43s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:17:35,769 - Epoch 2/2 \u2014 Train RMSE: 0.4156 \u2014 Validation RMSE: 0.4044\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:32<00:00, 16.30s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:17:47,596 - Epoch 1/2 \u2014 Train RMSE: 0.7253 \u2014 Validation RMSE: 0.7182\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:03<00:03,  3.14s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:17:50,413 - Epoch 2/2 \u2014 Train RMSE: 0.7224 \u2014 Validation RMSE: 0.7153\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:05<00:00,  2.98s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:17:51,143 - Trial 18 with params: {'idxAfterPrediction': 3, 'timesteps': 85, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 66, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 1.0241941769767601e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2022, 'is_single_feature': False}\n",
+            "2025-08-20 14:17:51,143 -   Duration0: 0:00:41.979798\n",
+            "2025-08-20 14:17:51,143 -   Duration1: 0:00:41.307537\n",
+            "2025-08-20 14:17:51,143 -   Duration2: 0:00:06.726632\n",
+            "2025-08-20 14:17:51,143 -   Val RMSE0 adjusted: 0.0110\n",
+            "2025-08-20 14:17:51,143 -   Val RMSE1 adjusted: 0.4044\n",
+            "2025-08-20 14:17:51,143 -   Val RMSE2 adjusted: 0.0108\n",
+            "2025-08-20 14:17:51,148 -   Mean all prediction: 1.0007\n",
+            "2025-08-20 14:17:51,148 -   Mean above prediction: 0.9970\n",
+            "2025-08-20 14:17:51,149 -   Mean below prediction: 0.9981\n",
+            "2025-08-20 14:17:51,149 -   Quantile 0.99 for distance in mask above: 4210.3999999999905\n",
+            "2025-08-20 14:17:51,149 -   Quantile 0.99 for distance in mask below: 3675.839999999993\n",
+            "2025-08-20 14:17:51,149 -   Ratio for quantile-distance-to-length above: 0.0064\n",
+            "2025-08-20 14:17:51,149 -   Ratio for quantile-distance-to-length below: 0.0056\n",
+            "2025-08-20 14:17:51,149 -   Score: 0.9990\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:17:51,198] Trial 18 finished with value: 0.9989849678026176 and parameters: {'year_start': 2022, 'idxAfterPrediction': 3, 'LoadupSamples_time_inc_factor': 66, 'timesteps': 85, 'LSTM_learning_rate': 1.0241941769767601e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.181084785939283, 'q2': 0.9899791932354101}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:17:51,198 - Trial 18 finished with value: 0.9989849678026176 and parameters: {'year_start': 2022, 'idxAfterPrediction': 3, 'LoadupSamples_time_inc_factor': 66, 'timesteps': 85, 'LSTM_learning_rate': 1.0241941769767601e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.181084785939283, 'q2': 0.9899791932354101}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:17:58,858 - Non-finite/too-large values in train y time: 48 samples.\n",
+            "2025-08-20 14:17:58,860 - Removing 48 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:18:27,938 - Epoch 1/2 \u2014 Train RMSE: 0.5841 \u2014 Validation RMSE: 0.4708\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:20<00:20, 20.17s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:18:49,535 - Epoch 2/2 \u2014 Train RMSE: 0.4291 \u2014 Validation RMSE: 0.3963\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:41<00:00, 20.88s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:19:19,715 - Epoch 1/2 \u2014 Train RMSE: 0.3140 \u2014 Validation RMSE: 0.2292\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:21<00:21, 21.12s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:19:40,725 - Epoch 2/2 \u2014 Train RMSE: 0.2350 \u2014 Validation RMSE: 0.2321\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:42<00:00, 21.07s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:19:55,055 - Epoch 1/2 \u2014 Train RMSE: 0.5421 \u2014 Validation RMSE: 0.5141\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:03<00:03,  3.44s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:19:58,135 - Epoch 2/2 \u2014 Train RMSE: 0.5085 \u2014 Validation RMSE: 0.4829\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:06<00:00,  3.26s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:19:58,782 - Trial 19 with params: {'idxAfterPrediction': 4, 'timesteps': 75, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 56, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 7.53489617345314e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2021, 'is_single_feature': True}\n",
+            "2025-08-20 14:19:58,782 -   Duration0: 0:00:50.709992\n",
+            "2025-08-20 14:19:58,782 -   Duration1: 0:00:53.015294\n",
+            "2025-08-20 14:19:58,785 -   Duration2: 0:00:07.191670\n",
+            "2025-08-20 14:19:58,785 -   Val RMSE0 adjusted: 0.0071\n",
+            "2025-08-20 14:19:58,785 -   Val RMSE1 adjusted: 0.2292\n",
+            "2025-08-20 14:19:58,785 -   Val RMSE2 adjusted: 0.0086\n",
+            "2025-08-20 14:19:58,788 -   Mean all prediction: 1.0011\n",
+            "2025-08-20 14:19:58,789 -   Mean above prediction: 1.0016\n",
+            "2025-08-20 14:19:58,789 -   Mean below prediction: 0.9994\n",
+            "2025-08-20 14:19:58,789 -   Quantile 0.99 for distance in mask above: 3452.7100000000014\n",
+            "2025-08-20 14:19:58,789 -   Quantile 0.99 for distance in mask below: 2006.0600000000004\n",
+            "2025-08-20 14:19:58,791 -   Ratio for quantile-distance-to-length above: 0.0052\n",
+            "2025-08-20 14:19:58,791 -   Ratio for quantile-distance-to-length below: 0.0030\n",
+            "2025-08-20 14:19:58,791 -   Score: 1.0004\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:19:58,862] Trial 19 finished with value: 1.0004026367312617 and parameters: {'year_start': 2021, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 56, 'timesteps': 75, 'LSTM_learning_rate': 7.53489617345314e-05, 'is_single_feature': True, 'apply_abs': True, 'q1': 0.1587921308492667, 'q2': 0.9762689450104796}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:19:58,862 - Trial 19 finished with value: 1.0004026367312617 and parameters: {'year_start': 2021, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 56, 'timesteps': 75, 'LSTM_learning_rate': 7.53489617345314e-05, 'is_single_feature': True, 'apply_abs': True, 'q1': 0.1587921308492667, 'q2': 0.9762689450104796}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:20:03,159 - Non-finite/too-large values in train y time: 48 samples.\n",
+            "2025-08-20 14:20:03,162 - Removing 48 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:20:18,149 - Epoch 1/2 \u2014 Train RMSE: 0.5114 \u2014 Validation RMSE: 0.3254\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:10<00:10, 10.82s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:20:29,539 - Epoch 2/2 \u2014 Train RMSE: 0.3154 \u2014 Validation RMSE: 0.3092\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.10s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:20:47,421 - Epoch 1/2 \u2014 Train RMSE: 0.3912 \u2014 Validation RMSE: 0.4034\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.23s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:20:58,642 - Epoch 2/2 \u2014 Train RMSE: 0.4230 \u2014 Validation RMSE: 0.4018\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.22s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:21:06,824 - Epoch 1/2 \u2014 Train RMSE: 0.4753 \u2014 Validation RMSE: 0.4362\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:02<00:02,  2.09s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:21:08,645 - Epoch 2/2 \u2014 Train RMSE: 0.4238 \u2014 Validation RMSE: 0.3898\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:03<00:00,  1.96s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:21:09,323 - Trial 20 with params: {'idxAfterPrediction': 4, 'timesteps': 65, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 26, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.0003430942547397925, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2023, 'is_single_feature': False}\n",
+            "2025-08-20 14:21:09,324 -   Duration0: 0:00:28.834816\n",
+            "2025-08-20 14:21:09,324 -   Duration1: 0:00:28.537007\n",
+            "2025-08-20 14:21:09,326 -   Duration2: 0:00:04.609322\n",
+            "2025-08-20 14:21:09,326 -   Val RMSE0 adjusted: 0.0119\n",
+            "2025-08-20 14:21:09,326 -   Val RMSE1 adjusted: 0.4018\n",
+            "2025-08-20 14:21:09,327 -   Val RMSE2 adjusted: 0.0150\n",
+            "2025-08-20 14:21:09,329 -   Mean all prediction: 1.0011\n",
+            "2025-08-20 14:21:09,329 -   Mean above prediction: 1.0001\n",
+            "2025-08-20 14:21:09,330 -   Mean below prediction: 0.9993\n",
+            "2025-08-20 14:21:09,331 -   Quantile 0.99 for distance in mask above: 1373.7599999999948\n",
+            "2025-08-20 14:21:09,331 -   Quantile 0.99 for distance in mask below: 1160.7599999999948\n",
+            "2025-08-20 14:21:09,332 -   Ratio for quantile-distance-to-length above: 0.0021\n",
+            "2025-08-20 14:21:09,333 -   Ratio for quantile-distance-to-length below: 0.0018\n",
+            "2025-08-20 14:21:09,333 -   Score: 1.0000\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:21:09,363] Trial 20 finished with value: 1.00003128243906 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 26, 'timesteps': 65, 'LSTM_learning_rate': 0.0003430942547397925, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.17572740987971622, 'q2': 0.960288572925532}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:21:09,363 - Trial 20 finished with value: 1.00003128243906 and parameters: {'year_start': 2023, 'idxAfterPrediction': 4, 'LoadupSamples_time_inc_factor': 26, 'timesteps': 65, 'LSTM_learning_rate': 0.0003430942547397925, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.17572740987971622, 'q2': 0.960288572925532}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:21:17,049 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 14:21:17,050 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:21:49,592 - Epoch 1/2 \u2014 Train RMSE: 0.4674 \u2014 Validation RMSE: 0.4220\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:22<00:22, 22.02s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:22:11,506 - Epoch 2/2 \u2014 Train RMSE: 0.4287 \u2014 Validation RMSE: 0.4215\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:43<00:00, 21.97s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:22:44,521 - Epoch 1/2 \u2014 Train RMSE: 0.3028 \u2014 Validation RMSE: 0.5691\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:21<00:21, 21.95s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:23:06,779 - Epoch 2/2 \u2014 Train RMSE: 0.3409 \u2014 Validation RMSE: 0.5518\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:44<00:00, 22.11s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:23:23,004 - Epoch 1/2 \u2014 Train RMSE: 0.5243 \u2014 Validation RMSE: 0.4175\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:04<00:04,  4.35s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:23:27,320 - Epoch 2/2 \u2014 Train RMSE: 0.4223 \u2014 Validation RMSE: 0.4167\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:08<00:00,  4.33s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:23:28,122 - Trial 21 with params: {'idxAfterPrediction': 5, 'timesteps': 90, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 66, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 0.0009852023673728213, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2021, 'is_single_feature': False}\n",
+            "2025-08-20 14:23:28,122 -   Duration0: 0:00:55.004775\n",
+            "2025-08-20 14:23:28,122 -   Duration1: 0:00:56.089446\n",
+            "2025-08-20 14:23:28,122 -   Duration2: 0:00:09.552832\n",
+            "2025-08-20 14:23:28,122 -   Val RMSE0 adjusted: 0.0064\n",
+            "2025-08-20 14:23:28,122 -   Val RMSE1 adjusted: 0.5518\n",
+            "2025-08-20 14:23:28,122 -   Val RMSE2 adjusted: 0.0063\n",
+            "2025-08-20 14:23:28,122 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 14:23:28,128 -   Mean above prediction: 0.9992\n",
+            "2025-08-20 14:23:28,128 -   Mean below prediction: 1.0020\n",
+            "2025-08-20 14:23:28,129 -   Quantile 0.99 for distance in mask above: 711.29\n",
+            "2025-08-20 14:23:28,129 -   Quantile 0.99 for distance in mask below: 786.5799999999999\n",
+            "2025-08-20 14:23:28,129 -   Ratio for quantile-distance-to-length above: 0.0011\n",
+            "2025-08-20 14:23:28,132 -   Ratio for quantile-distance-to-length below: 0.0012\n",
+            "2025-08-20 14:23:28,132 -   Score: 0.9998\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:23:28,193] Trial 21 finished with value: 0.9998479971895021 and parameters: {'year_start': 2021, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 66, 'timesteps': 90, 'LSTM_learning_rate': 0.0009852023673728213, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.19939127165689902, 'q2': 0.9437891985949042}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:23:28,193 - Trial 21 finished with value: 0.9998479971895021 and parameters: {'year_start': 2021, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 66, 'timesteps': 90, 'LSTM_learning_rate': 0.0009852023673728213, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.19939127165689902, 'q2': 0.9437891985949042}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:23:34,189 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 14:23:34,189 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:23:56,063 - Epoch 1/2 \u2014 Train RMSE: 0.5897 \u2014 Validation RMSE: 0.5045\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.28s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:24:12,786 - Epoch 2/2 \u2014 Train RMSE: 0.4662 \u2014 Validation RMSE: 0.4288\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:33<00:00, 16.50s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:24:38,310 - Epoch 1/2 \u2014 Train RMSE: 0.4283 \u2014 Validation RMSE: 0.4076\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.75s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:24:55,189 - Epoch 2/2 \u2014 Train RMSE: 0.4216 \u2014 Validation RMSE: 0.4012\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:33<00:00, 16.81s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:25:06,483 - Epoch 1/2 \u2014 Train RMSE: 0.6613 \u2014 Validation RMSE: 0.6588\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:02<00:02,  2.65s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:25:09,048 - Epoch 2/2 \u2014 Train RMSE: 0.6287 \u2014 Validation RMSE: 0.6269\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:05<00:00,  2.61s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:25:09,704 - Trial 22 with params: {'idxAfterPrediction': 5, 'timesteps': 60, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 71, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 9.610375975212033e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2022, 'is_single_feature': False}\n",
+            "2025-08-20 14:25:09,709 -   Duration0: 0:00:41.694530\n",
+            "2025-08-20 14:25:09,709 -   Duration1: 0:00:42.289307\n",
+            "2025-08-20 14:25:09,709 -   Duration2: 0:00:05.895601\n",
+            "2025-08-20 14:25:09,709 -   Val RMSE0 adjusted: 0.0060\n",
+            "2025-08-20 14:25:09,710 -   Val RMSE1 adjusted: 0.4012\n",
+            "2025-08-20 14:25:09,711 -   Val RMSE2 adjusted: 0.0088\n",
+            "2025-08-20 14:25:09,711 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 14:25:09,711 -   Mean above prediction: 1.0063\n",
+            "2025-08-20 14:25:09,713 -   Mean below prediction: 1.0034\n",
+            "2025-08-20 14:25:09,714 -   Quantile 0.99 for distance in mask above: 3751.6399999999967\n",
+            "2025-08-20 14:25:09,715 -   Quantile 0.99 for distance in mask below: 3605.759999999986\n",
+            "2025-08-20 14:25:09,715 -   Ratio for quantile-distance-to-length above: 0.0057\n",
+            "2025-08-20 14:25:09,715 -   Ratio for quantile-distance-to-length below: 0.0055\n",
+            "2025-08-20 14:25:09,715 -   Score: 1.0012\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:25:09,754] Trial 22 finished with value: 1.0012476745320606 and parameters: {'year_start': 2022, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 60, 'LSTM_learning_rate': 9.610375975212033e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.15572612694391513, 'q2': 0.9810824706828459}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:25:09,754 - Trial 22 finished with value: 1.0012476745320606 and parameters: {'year_start': 2022, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 60, 'LSTM_learning_rate': 9.610375975212033e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.15572612694391513, 'q2': 0.9810824706828459}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:25:15,713 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 14:25:15,715 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:25:37,421 - Epoch 1/2 \u2014 Train RMSE: 0.5654 \u2014 Validation RMSE: 0.4998\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.15s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:25:54,089 - Epoch 2/2 \u2014 Train RMSE: 0.4738 \u2014 Validation RMSE: 0.4378\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:32<00:00, 16.41s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:26:19,307 - Epoch 1/2 \u2014 Train RMSE: 0.4622 \u2014 Validation RMSE: 0.4254\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:16<00:16, 16.54s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:26:36,022 - Epoch 2/2 \u2014 Train RMSE: 0.4436 \u2014 Validation RMSE: 0.4115\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:33<00:00, 16.63s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:26:47,191 - Epoch 1/2 \u2014 Train RMSE: 0.4982 \u2014 Validation RMSE: 0.4880\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:02<00:02,  2.49s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:26:49,360 - Epoch 2/2 \u2014 Train RMSE: 0.4903 \u2014 Validation RMSE: 0.4803\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:04<00:00,  2.33s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:26:49,985 - Trial 23 with params: {'idxAfterPrediction': 5, 'timesteps': 60, 'target_option': 'last', 'LoadupSamples_time_scaling_stretch': True, 'LoadupSamples_time_inc_factor': 71, 'LSTM_units': 16, 'LSTM_num_layers': 1, 'LSTM_dropout': 0.001, 'LSTM_recurrent_dropout': 0.001, 'LSTM_learning_rate': 6.006724165455484e-05, 'LSTM_optimizer': 'adam', 'LSTM_bidirectional': True, 'LSTM_batch_size': 4096, 'LSTM_epochs': 2, 'LSTM_l1': 0.001, 'LSTM_l2': 0.001, 'LSTM_inter_dropout': 0.001, 'LSTM_input_gaussian_noise': 0.001, 'LSTM_conv1d': True, 'LSTM_conv1d_kernel_size': 3, 'LSTM_loss': 'mse', 'year_start': 2022, 'is_single_feature': False}\n",
+            "2025-08-20 14:26:49,985 -   Duration0: 0:00:41.451367\n",
+            "2025-08-20 14:26:49,985 -   Duration1: 0:00:41.956481\n",
+            "2025-08-20 14:26:49,985 -   Duration2: 0:00:05.299902\n",
+            "2025-08-20 14:26:49,989 -   Val RMSE0 adjusted: 0.0062\n",
+            "2025-08-20 14:26:49,989 -   Val RMSE1 adjusted: 0.4115\n",
+            "2025-08-20 14:26:49,989 -   Val RMSE2 adjusted: 0.0068\n",
+            "2025-08-20 14:26:49,989 -   Mean all prediction: 1.0015\n",
+            "2025-08-20 14:26:49,989 -   Mean above prediction: 1.0040\n",
+            "2025-08-20 14:26:49,992 -   Mean below prediction: 1.0031\n",
+            "2025-08-20 14:26:49,992 -   Quantile 0.99 for distance in mask above: 3945.239999999998\n",
+            "2025-08-20 14:26:49,992 -   Quantile 0.99 for distance in mask below: 3791.2\n",
+            "2025-08-20 14:26:49,994 -   Ratio for quantile-distance-to-length above: 0.0060\n",
+            "2025-08-20 14:26:49,994 -   Ratio for quantile-distance-to-length below: 0.0058\n",
+            "2025-08-20 14:26:49,994 -   Score: 1.0008\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[I 2025-08-20 14:26:50,030] Trial 23 finished with value: 1.000797533708613 and parameters: {'year_start': 2022, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 60, 'LSTM_learning_rate': 6.006724165455484e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.1411010625575955, 'q2': 0.9817118710645898}. Best is trial 6 with value: 1.0047707591863355.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:26:50,030 - Trial 23 finished with value: 1.000797533708613 and parameters: {'year_start': 2022, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 71, 'timesteps': 60, 'LSTM_learning_rate': 6.006724165455484e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.1411010625575955, 'q2': 0.9817118710645898}. Best is trial 6 with value: 1.0047707591863355.\n",
+            "2025-08-20 14:26:54,363 - Non-finite/too-large values in train y time: 60 samples.\n",
+            "2025-08-20 14:26:54,370 - Removing 60 samples from training data.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:27:09,362 - Epoch 1/2 \u2014 Train RMSE: 0.6526 \u2014 Validation RMSE: 0.6208\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.05s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:27:20,920 - Epoch 2/2 \u2014 Train RMSE: 0.6287 \u2014 Validation RMSE: 0.5977\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:22<00:00, 11.31s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:00<?, ?it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:27:38,629 - Epoch 1/2 \u2014 Train RMSE: 0.4251 \u2014 Validation RMSE: 0.4051\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs:  50%|\u2588\u2588\u2588\u2588\u2588     | 1/2 [00:11<00:11, 11.52s/it]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:27:50,131 - Epoch 2/2 \u2014 Train RMSE: 0.4234 \u2014 Validation RMSE: 0.4035\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Epochs: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 2/2 [00:23<00:00, 11.51s/it]\n",
+            "Epochs:   0%|          | 0/2 [00:01<?, ?it/s]\n",
+            "[W 2025-08-20 14:27:58,198] Trial 24 failed with parameters: {'year_start': 2023, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 66, 'timesteps': 60, 'LSTM_learning_rate': 2.257064722122752e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.16069329522137288} because of the following error: KeyboardInterrupt().\n",
+            "Traceback (most recent call last):\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\optuna\\study\\_optimize.py\", line 197, in _run_trial\n",
+            "    value_or_values = func(trial)\n",
+            "                      ^^^^^^^^^^^\n",
+            "  File \"C:\\Users\\kimer\\AppData\\Local\\Temp\\ipykernel_7948\\2387001626.py\", line 84, in objective\n",
+            "    model_lstm2, res_dict2 = mm.run_LSTM_torch(Xtrain[mask_pred_train_err], ytrain[mask_pred_train_err], Xtest[mask_pred_test_err], ytest[mask_pred_test_err], device=\"cuda\")\n",
+            "                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\src\\predictionModule\\MachineModels.py\", line 560, in run_LSTM_torch\n",
+            "    for X_batch, y_batch in tqdm(val_loader, desc='Validation', leave=False):\n",
+            "                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\tqdm\\std.py\", line 1181, in __iter__\n",
+            "    for obj in iterable:\n",
+            "               ^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataloader.py\", line 733, in __next__\n",
+            "    data = self._next_data()\n",
+            "           ^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataloader.py\", line 789, in _next_data\n",
+            "    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\_utils\\fetch.py\", line 52, in fetch\n",
+            "    data = [self.dataset[idx] for idx in possibly_batched_index]\n",
+            "            ~~~~~~~~~~~~^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataset.py\", line 207, in __getitem__\n",
+            "    return tuple(tensor[index] for tensor in self.tensors)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataset.py\", line 207, in <genexpr>\n",
+            "    return tuple(tensor[index] for tensor in self.tensors)\n",
+            "                 ~~~~~~^^^^^^^\n",
+            "KeyboardInterrupt\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:27:58,198 - Trial 24 failed with parameters: {'year_start': 2023, 'idxAfterPrediction': 5, 'LoadupSamples_time_inc_factor': 66, 'timesteps': 60, 'LSTM_learning_rate': 2.257064722122752e-05, 'is_single_feature': False, 'apply_abs': False, 'q1': 0.16069329522137288} because of the following error: KeyboardInterrupt().\n",
+            "Traceback (most recent call last):\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\optuna\\study\\_optimize.py\", line 197, in _run_trial\n",
+            "    value_or_values = func(trial)\n",
+            "                      ^^^^^^^^^^^\n",
+            "  File \"C:\\Users\\kimer\\AppData\\Local\\Temp\\ipykernel_7948\\2387001626.py\", line 84, in objective\n",
+            "    model_lstm2, res_dict2 = mm.run_LSTM_torch(Xtrain[mask_pred_train_err], ytrain[mask_pred_train_err], Xtest[mask_pred_test_err], ytest[mask_pred_test_err], device=\"cuda\")\n",
+            "                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\src\\predictionModule\\MachineModels.py\", line 560, in run_LSTM_torch\n",
+            "    for X_batch, y_batch in tqdm(val_loader, desc='Validation', leave=False):\n",
+            "                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\tqdm\\std.py\", line 1181, in __iter__\n",
+            "    for obj in iterable:\n",
+            "               ^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataloader.py\", line 733, in __next__\n",
+            "    data = self._next_data()\n",
+            "           ^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataloader.py\", line 789, in _next_data\n",
+            "    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\_utils\\fetch.py\", line 52, in fetch\n",
+            "    data = [self.dataset[idx] for idx in possibly_batched_index]\n",
+            "            ~~~~~~~~~~~~^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataset.py\", line 207, in __getitem__\n",
+            "    return tuple(tensor[index] for tensor in self.tensors)\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"c:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataset.py\", line 207, in <genexpr>\n",
+            "    return tuple(tensor[index] for tensor in self.tensors)\n",
+            "                 ~~~~~~^^^^^^^\n",
+            "KeyboardInterrupt\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[W 2025-08-20 14:27:58,228] Trial 24 failed with value None.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-20 14:27:58,228 - Trial 24 failed with value None.\n"
+          ]
+        },
+        {
+          "ename": "KeyboardInterrupt",
+          "evalue": "",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mKeyboardInterrupt\u001b[39m                         Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 135\u001b[39m\n\u001b[32m    127\u001b[39m sampler = optuna.samplers.TPESampler(n_startup_trials=\u001b[32m5\u001b[39m)\n\u001b[32m    128\u001b[39m study = optuna.create_study(\n\u001b[32m    129\u001b[39m     study_name = studyname,\n\u001b[32m    130\u001b[39m     storage=\u001b[33m\"\u001b[39m\u001b[33msqlite:///sandbox_optuna.db\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m   (...)\u001b[39m\u001b[32m    133\u001b[39m     sampler=sampler,\n\u001b[32m    134\u001b[39m )\n\u001b[32m--> \u001b[39m\u001b[32m135\u001b[39m \u001b[43mstudy\u001b[49m\u001b[43m.\u001b[49m\u001b[43moptimize\u001b[49m\u001b[43m(\u001b[49m\u001b[43mobjective\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m=\u001b[49m\u001b[43mstudytime\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    137\u001b[39m logger.info(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mBest parameters: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mstudy.best_params\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m    138\u001b[39m logger.info(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mBest score: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mstudy.best_value\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\optuna\\study\\study.py:475\u001b[39m, in \u001b[36mStudy.optimize\u001b[39m\u001b[34m(self, func, n_trials, timeout, n_jobs, catch, callbacks, gc_after_trial, show_progress_bar)\u001b[39m\n\u001b[32m    373\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34moptimize\u001b[39m(\n\u001b[32m    374\u001b[39m     \u001b[38;5;28mself\u001b[39m,\n\u001b[32m    375\u001b[39m     func: ObjectiveFuncType,\n\u001b[32m   (...)\u001b[39m\u001b[32m    382\u001b[39m     show_progress_bar: \u001b[38;5;28mbool\u001b[39m = \u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[32m    383\u001b[39m ) -> \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m    384\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Optimize an objective function.\u001b[39;00m\n\u001b[32m    385\u001b[39m \n\u001b[32m    386\u001b[39m \u001b[33;03m    Optimization is done by choosing a suitable set of hyperparameter values from a given\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m    473\u001b[39m \u001b[33;03m            If nested invocation of this method occurs.\u001b[39;00m\n\u001b[32m    474\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m475\u001b[39m     \u001b[43m_optimize\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    476\u001b[39m \u001b[43m        \u001b[49m\u001b[43mstudy\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m    477\u001b[39m \u001b[43m        \u001b[49m\u001b[43mfunc\u001b[49m\u001b[43m=\u001b[49m\u001b[43mfunc\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    478\u001b[39m \u001b[43m        \u001b[49m\u001b[43mn_trials\u001b[49m\u001b[43m=\u001b[49m\u001b[43mn_trials\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    479\u001b[39m \u001b[43m        \u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m=\u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    480\u001b[39m \u001b[43m        \u001b[49m\u001b[43mn_jobs\u001b[49m\u001b[43m=\u001b[49m\u001b[43mn_jobs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    481\u001b[39m \u001b[43m        \u001b[49m\u001b[43mcatch\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mtuple\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mcatch\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mif\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43misinstance\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mcatch\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mIterable\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01melse\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43m(\u001b[49m\u001b[43mcatch\u001b[49m\u001b[43m,\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    482\u001b[39m \u001b[43m        \u001b[49m\u001b[43mcallbacks\u001b[49m\u001b[43m=\u001b[49m\u001b[43mcallbacks\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    483\u001b[39m \u001b[43m        \u001b[49m\u001b[43mgc_after_trial\u001b[49m\u001b[43m=\u001b[49m\u001b[43mgc_after_trial\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    484\u001b[39m \u001b[43m        \u001b[49m\u001b[43mshow_progress_bar\u001b[49m\u001b[43m=\u001b[49m\u001b[43mshow_progress_bar\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    485\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\optuna\\study\\_optimize.py:63\u001b[39m, in \u001b[36m_optimize\u001b[39m\u001b[34m(study, func, n_trials, timeout, n_jobs, catch, callbacks, gc_after_trial, show_progress_bar)\u001b[39m\n\u001b[32m     61\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m     62\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m n_jobs == \u001b[32m1\u001b[39m:\n\u001b[32m---> \u001b[39m\u001b[32m63\u001b[39m         \u001b[43m_optimize_sequential\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m     64\u001b[39m \u001b[43m            \u001b[49m\u001b[43mstudy\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     65\u001b[39m \u001b[43m            \u001b[49m\u001b[43mfunc\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     66\u001b[39m \u001b[43m            \u001b[49m\u001b[43mn_trials\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     67\u001b[39m \u001b[43m            \u001b[49m\u001b[43mtimeout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     68\u001b[39m \u001b[43m            \u001b[49m\u001b[43mcatch\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     69\u001b[39m \u001b[43m            \u001b[49m\u001b[43mcallbacks\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     70\u001b[39m \u001b[43m            \u001b[49m\u001b[43mgc_after_trial\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     71\u001b[39m \u001b[43m            \u001b[49m\u001b[43mreseed_sampler_rng\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m     72\u001b[39m \u001b[43m            \u001b[49m\u001b[43mtime_start\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m     73\u001b[39m \u001b[43m            \u001b[49m\u001b[43mprogress_bar\u001b[49m\u001b[43m=\u001b[49m\u001b[43mprogress_bar\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     74\u001b[39m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     75\u001b[39m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m     76\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m n_jobs == -\u001b[32m1\u001b[39m:\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\optuna\\study\\_optimize.py:160\u001b[39m, in \u001b[36m_optimize_sequential\u001b[39m\u001b[34m(study, func, n_trials, timeout, catch, callbacks, gc_after_trial, reseed_sampler_rng, time_start, progress_bar)\u001b[39m\n\u001b[32m    157\u001b[39m         \u001b[38;5;28;01mbreak\u001b[39;00m\n\u001b[32m    159\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m160\u001b[39m     frozen_trial = \u001b[43m_run_trial\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstudy\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfunc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcatch\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    161\u001b[39m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[32m    162\u001b[39m     \u001b[38;5;66;03m# The following line mitigates memory problems that can be occurred in some\u001b[39;00m\n\u001b[32m    163\u001b[39m     \u001b[38;5;66;03m# environments (e.g., services that use computing containers such as GitHub Actions).\u001b[39;00m\n\u001b[32m    164\u001b[39m     \u001b[38;5;66;03m# Please refer to the following PR for further details:\u001b[39;00m\n\u001b[32m    165\u001b[39m     \u001b[38;5;66;03m# https://github.com/optuna/optuna/pull/325.\u001b[39;00m\n\u001b[32m    166\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m gc_after_trial:\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\optuna\\study\\_optimize.py:248\u001b[39m, in \u001b[36m_run_trial\u001b[39m\u001b[34m(study, func, catch)\u001b[39m\n\u001b[32m    241\u001b[39m         \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28;01mFalse\u001b[39;00m, \u001b[33m\"\u001b[39m\u001b[33mShould not reach.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    243\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m (\n\u001b[32m    244\u001b[39m     frozen_trial.state == TrialState.FAIL\n\u001b[32m    245\u001b[39m     \u001b[38;5;129;01mand\u001b[39;00m func_err \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    246\u001b[39m     \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(func_err, catch)\n\u001b[32m    247\u001b[39m ):\n\u001b[32m--> \u001b[39m\u001b[32m248\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m func_err\n\u001b[32m    249\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m frozen_trial\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\optuna\\study\\_optimize.py:197\u001b[39m, in \u001b[36m_run_trial\u001b[39m\u001b[34m(study, func, catch)\u001b[39m\n\u001b[32m    195\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m get_heartbeat_thread(trial._trial_id, study._storage):\n\u001b[32m    196\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m197\u001b[39m         value_or_values = \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtrial\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    198\u001b[39m     \u001b[38;5;28;01mexcept\u001b[39;00m exceptions.TrialPruned \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[32m    199\u001b[39m         \u001b[38;5;66;03m# TODO(mamu): Handle multi-objective cases.\u001b[39;00m\n\u001b[32m    200\u001b[39m         state = TrialState.PRUNED\n",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 84\u001b[39m, in \u001b[36mobjective\u001b[39m\u001b[34m(trial)\u001b[39m\n\u001b[32m     82\u001b[39m \u001b[38;5;66;03m#run again\u001b[39;00m\n\u001b[32m     83\u001b[39m starttime2 = datetime.datetime.now()\n\u001b[32m---> \u001b[39m\u001b[32m84\u001b[39m model_lstm2, res_dict2 = \u001b[43mmm\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun_LSTM_torch\u001b[49m\u001b[43m(\u001b[49m\u001b[43mXtrain\u001b[49m\u001b[43m[\u001b[49m\u001b[43mmask_pred_train_err\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mytrain\u001b[49m\u001b[43m[\u001b[49m\u001b[43mmask_pred_train_err\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mXtest\u001b[49m\u001b[43m[\u001b[49m\u001b[43mmask_pred_test_err\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mytest\u001b[49m\u001b[43m[\u001b[49m\u001b[43mmask_pred_test_err\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcuda\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m     85\u001b[39m preds_test2 = mm.predict_LSTM_torch(model_lstm2, Xtest[mask_pred_test_err], batch_size=opt_params[\u001b[33m\"\u001b[39m\u001b[33mLSTM_batch_size\u001b[39m\u001b[33m\"\u001b[39m], device=\u001b[33m\"\u001b[39m\u001b[33mcuda\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     86\u001b[39m endtime2 = datetime.datetime.now()\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\src\\predictionModule\\MachineModels.py:560\u001b[39m, in \u001b[36mMachineModels.run_LSTM_torch\u001b[39m\u001b[34m(self, X_train, y_train, X_test, y_test, device)\u001b[39m\n\u001b[32m    558\u001b[39m val_rmses = []\n\u001b[32m    559\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m torch.no_grad():\n\u001b[32m--> \u001b[39m\u001b[32m560\u001b[39m \u001b[43m    \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mX_batch\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my_batch\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mtqdm\u001b[49m\u001b[43m(\u001b[49m\u001b[43mval_loader\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdesc\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mValidation\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mleave\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m:\u001b[49m\n\u001b[32m    561\u001b[39m \u001b[43m        \u001b[49m\u001b[43mX_batch\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my_batch\u001b[49m\u001b[43m \u001b[49m\u001b[43m=\u001b[49m\u001b[43m \u001b[49m\u001b[43mX_batch\u001b[49m\u001b[43m.\u001b[49m\u001b[43mto\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my_batch\u001b[49m\u001b[43m.\u001b[49m\u001b[43mto\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    562\u001b[39m \u001b[43m        \u001b[49m\u001b[43mpreds\u001b[49m\u001b[43m \u001b[49m\u001b[43m=\u001b[49m\u001b[43m \u001b[49m\u001b[43mmodel\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX_batch\u001b[49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[43msqueeze\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\tqdm\\std.py:1181\u001b[39m, in \u001b[36mtqdm.__iter__\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m   1178\u001b[39m time = \u001b[38;5;28mself\u001b[39m._time\n\u001b[32m   1180\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m1181\u001b[39m \u001b[43m    \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mobj\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43miterable\u001b[49m\u001b[43m:\u001b[49m\n\u001b[32m   1182\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43;01myield\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mobj\u001b[49m\n\u001b[32m   1183\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# Update and possibly print the progressbar.\u001b[39;49;00m\n\u001b[32m   1184\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;66;43;03m# Note: does not call self.update(1) for speed optimisation.\u001b[39;49;00m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataloader.py:733\u001b[39m, in \u001b[36m_BaseDataLoaderIter.__next__\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    730\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m._sampler_iter \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m    731\u001b[39m     \u001b[38;5;66;03m# TODO(https://github.com/pytorch/pytorch/issues/76750)\u001b[39;00m\n\u001b[32m    732\u001b[39m     \u001b[38;5;28mself\u001b[39m._reset()  \u001b[38;5;66;03m# type: ignore[call-arg]\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m733\u001b[39m data = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_next_data\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    734\u001b[39m \u001b[38;5;28mself\u001b[39m._num_yielded += \u001b[32m1\u001b[39m\n\u001b[32m    735\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m (\n\u001b[32m    736\u001b[39m     \u001b[38;5;28mself\u001b[39m._dataset_kind == _DatasetKind.Iterable\n\u001b[32m    737\u001b[39m     \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28mself\u001b[39m._IterableDataset_len_called \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    738\u001b[39m     \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28mself\u001b[39m._num_yielded > \u001b[38;5;28mself\u001b[39m._IterableDataset_len_called\n\u001b[32m    739\u001b[39m ):\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataloader.py:789\u001b[39m, in \u001b[36m_SingleProcessDataLoaderIter._next_data\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    787\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_next_data\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[32m    788\u001b[39m     index = \u001b[38;5;28mself\u001b[39m._next_index()  \u001b[38;5;66;03m# may raise StopIteration\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m789\u001b[39m     data = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_dataset_fetcher\u001b[49m\u001b[43m.\u001b[49m\u001b[43mfetch\u001b[49m\u001b[43m(\u001b[49m\u001b[43mindex\u001b[49m\u001b[43m)\u001b[49m  \u001b[38;5;66;03m# may raise StopIteration\u001b[39;00m\n\u001b[32m    790\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m._pin_memory:\n\u001b[32m    791\u001b[39m         data = _utils.pin_memory.pin_memory(data, \u001b[38;5;28mself\u001b[39m._pin_memory_device)\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\_utils\\fetch.py:52\u001b[39m, in \u001b[36m_MapDatasetFetcher.fetch\u001b[39m\u001b[34m(self, possibly_batched_index)\u001b[39m\n\u001b[32m     50\u001b[39m         data = \u001b[38;5;28mself\u001b[39m.dataset.__getitems__(possibly_batched_index)\n\u001b[32m     51\u001b[39m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m52\u001b[39m         data = [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mdataset\u001b[49m\u001b[43m[\u001b[49m\u001b[43midx\u001b[49m\u001b[43m]\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m idx \u001b[38;5;129;01min\u001b[39;00m possibly_batched_index]\n\u001b[32m     53\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m     54\u001b[39m     data = \u001b[38;5;28mself\u001b[39m.dataset[possibly_batched_index]\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataset.py:207\u001b[39m, in \u001b[36mTensorDataset.__getitem__\u001b[39m\u001b[34m(self, index)\u001b[39m\n\u001b[32m    206\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m__getitem__\u001b[39m(\u001b[38;5;28mself\u001b[39m, index):\n\u001b[32m--> \u001b[39m\u001b[32m207\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mtuple\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mtensor\u001b[49m\u001b[43m[\u001b[49m\u001b[43mindex\u001b[49m\u001b[43m]\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mtensor\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mtensors\u001b[49m\u001b[43m)\u001b[49m\n",
+            "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\kimer\\Desktop\\RandomOdyssey\\.venv\\Lib\\site-packages\\torch\\utils\\data\\dataset.py:207\u001b[39m, in \u001b[36m<genexpr>\u001b[39m\u001b[34m(.0)\u001b[39m\n\u001b[32m    206\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m__getitem__\u001b[39m(\u001b[38;5;28mself\u001b[39m, index):\n\u001b[32m--> \u001b[39m\u001b[32m207\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mtuple\u001b[39m(tensor[index] \u001b[38;5;28;01mfor\u001b[39;00m tensor \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.tensors)\n",
+            "\u001b[31mKeyboardInterrupt\u001b[39m: "
+          ]
+        }
+      ],
+      "source": [
+        "def objective(trial: optuna.Trial) -> float:\n",
+        "    q_full = 0.998\n",
+        "    opt_params = params_default.copy()\n",
+        "    opt_params[\"year_start\"] = trial.suggest_int(\"year_start\", 2019, 2023)\n",
+        "    opt_params[\"idxAfterPrediction\"] = trial.suggest_int(\"idxAfterPrediction\", 1, 5, step=1)\n",
+        "    opt_params[\"LoadupSamples_time_inc_factor\"] = trial.suggest_int(\"LoadupSamples_time_inc_factor\", 11, 71, step=5)\n",
+        "    opt_params[\"timesteps\"] = trial.suggest_int(\"timesteps\", 30, 90, step=5)\n",
+        "    opt_params[\"LSTM_units\"] = 16\n",
+        "    opt_params[\"LSTM_num_layers\"] = 1\n",
+        "    opt_params[\"LSTM_learning_rate\"] = trial.suggest_float(\"LSTM_learning_rate\", 1e-5, 1e-2, log=True)\n",
+        "    opt_params[\"LSTM_epochs\"] = 2\n",
+        "    #opt_params[\"LSTM_l1\"] = trial.suggest_float(\"LSTM_l1\", 1e-5, 1e-3, log=True)\n",
+        "    #opt_params[\"LSTM_l2\"] = trial.suggest_float(\"LSTM_l2\", 1e-4, 1e-1, log=True)\n",
+        "    opt_params[\"LSTM_dropout\"] = trial.suggest_float(\"LSTM_dropout\", 1e-3, 1e-1, log=True)\n",
+        "    #opt_params[\"LSTM_inter_dropout\"] = trial.suggest_float(\"LSTM_inter_dropout\", 1e-4, 1e-1, log=True)\n",
+        "    #opt_params[\"LSTM_recurrent_dropout\"] = trial.suggest_float(\"LSTM_recurrent_dropout\", 1e-4, 1e-1, log=True)\n",
+        "    opt_params[\"LSTM_conv1d_kernel_size\"] = 3\n",
+        "    opt_params[\"LSTM_transformer_before\"] = trial.suggest_categorical(\"LSTM_transformer_before\", [False, True])\n",
+        "    opt_params[\"LSTM_transformer_after\"] = trial.suggest_categorical(\"LSTM_transformer_after\", [False, True])\n",
+        "    opt_params[\"LSTM_tf_nhead\"] = trial.suggest_categorical(\"LSTM_tf_nhead\", [2,4,8])\n",
+        "    opt_params[\"LSTM_tf_num_layers_before\"] = trial.suggest_int(\"LSTM_tf_num_layers_before\", 0, 2)\n",
+        "    opt_params[\"LSTM_tf_num_layers_after\"] = trial.suggest_int(\"LSTM_tf_num_layers_after\", 0, 2)\n",
+        "    opt_params[\"LSTM_tf_dim_feedforward\"] = trial.suggest_int(\"LSTM_tf_dim_feedforward\", 64, 512)\n",
+        "    opt_params[\"LSTM_tf_dropout\"] = trial.suggest_float(\"LSTM_tf_dropout\", 0.0, 0.3)\n",
+        "    opt_params[\"is_single_feature\"] = trial.suggest_categorical(\"is_single_feature\", [True, False])\n",
+        "    apply_abs = trial.suggest_categorical(\"apply_abs\", [True, False])\n",
+        "    q_err = trial.suggest_float(\"q_err\", 0.01, 0.2, log = True)\n",
+        "\n",
+        "    ls = LoadupSamples(\n",
+        "        train_start_date=datetime.date(year=opt_params[\"year_start\"], month=1, day=1),\n",
+        "        test_dates=[eval_date],\n",
+        "        treegroup=None,\n",
+        "        timegroup=stock_group,\n",
+        "        params=opt_params,\n",
+        "    )\n",
+        "    ls.load_samples(main_path = \"../src/featureAlchemy/bin/\")\n",
+        "\n",
+        "    ls.split_dataset(\n",
+        "        start_date=datetime.date(year=opt_params[\"year_start\"], month=1, day=1),\n",
+        "        last_train_date=split_date,\n",
+        "        last_test_date=eval_date,\n",
+        "    )\n",
+        "\n",
+        "    Xtrain = ls.train_Xtime\n",
+        "    ytrain = ls.train_ytime\n",
+        "    Xtest = ls.test_Xtime\n",
+        "    ytest = ls.test_ytime\n",
+        "\n",
+        "    true_res = ls.meta_pl_test\n",
+        "\n",
+        "    Xtrain = Xtrain[:, -opt_params[\"timesteps\"]:, :]\n",
+        "    Xtest = Xtest[:, -opt_params[\"timesteps\"]:, :]\n",
+        "\n",
+        "    if opt_params[\"is_single_feature\"]:\n",
+        "        Xtrain = Xtrain[:, :, [0]]\n",
+        "        Xtest = Xtest[:, :, [0]]\n",
+        "\n",
+        "    mm = MachineModels(opt_params)\n",
+        "\n",
+        "    starttime0 = datetime.datetime.now()\n",
+        "    model_lstm0, res_dict0 = mm.run_LSTM_transformer_torch(Xtrain, ytrain, Xtest, ytest, device=\"cuda\")\n",
+        "    preds_train0 = mm.predict_LSTM_transformer_torch(model_lstm0, Xtrain, batch_size=opt_params[\"LSTM_batch_size\"], device=\"cuda\")\n",
+        "    preds_test0 = mm.predict_LSTM_transformer_torch(model_lstm0, Xtest, batch_size=opt_params[\"LSTM_batch_size\"], device=\"cuda\")\n",
+        "    endtime0 = datetime.datetime.now()\n",
+        "\n",
+        "    argsort_train = np.argsort(ytrain)\n",
+        "    argsort_test = np.argsort(ytest)\n",
+        "    preds_train0_sorted = preds_train0[argsort_train]\n",
+        "    preds_test0_sorted = preds_test0[argsort_test]\n",
+        "    argsort_pred_train_sorted = np.argsort(preds_train0_sorted)\n",
+        "    argsort_pred_test_sorted = np.argsort(preds_test0_sorted)\n",
+        "    err_vec_train = np.linspace(0,1,len(preds_train0_sorted)) - argsort_pred_train_sorted / (len(preds_train0_sorted)-1)\n",
+        "    err_vec_test = np.linspace(0,1,len(preds_test0_sorted)) - argsort_pred_test_sorted / (len(preds_test0_sorted)-1)\n",
+        "    if apply_abs:\n",
+        "        err_vec_train = np.abs(err_vec_train)\n",
+        "        err_vec_test = np.abs(err_vec_test)\n",
+        "\n",
+        "    #run again with err_vec\n",
+        "    starttime1 = datetime.datetime.now()\n",
+        "    model_lstm1, res_dict1 = mm.run_LSTM_transformer_torch(Xtrain, err_vec_train, Xtest, err_vec_test, device=\"cuda\")\n",
+        "    preds_train1 = mm.predict_LSTM_transformer_torch(model_lstm1, Xtrain, batch_size=opt_params[\"LSTM_batch_size\"], device=\"cuda\")\n",
+        "    preds_test1 = mm.predict_LSTM_transformer_torch(model_lstm1, Xtest, batch_size=opt_params[\"LSTM_batch_size\"], device=\"cuda\")\n",
+        "    endtime1 = datetime.datetime.now()\n",
+        "\n",
+        "    # err mask\n",
+        "    mask_pred_test_err = (np.abs(preds_test1) <= np.quantile(np.abs(preds_test1), q_err))\n",
+        "    mask_pred_train_err = (np.abs(preds_train1) <= np.quantile(np.abs(preds_train1), q_err))\n",
+        "\n",
+        "    #run again\n",
+        "    starttime2 = datetime.datetime.now()\n",
+        "    model_lstm2, res_dict2 = mm.run_LSTM_transformer_torch(Xtrain[mask_pred_train_err], ytrain[mask_pred_train_err], Xtest[mask_pred_test_err], ytest[mask_pred_test_err], device=\"cuda\")\n",
+        "    preds_test2 = mm.predict_LSTM_transformer_torch(model_lstm2, Xtest[mask_pred_test_err], batch_size=opt_params[\"LSTM_batch_size\"], device=\"cuda\")\n",
+        "    endtime2 = datetime.datetime.now()\n",
+        "\n",
+        "    # final mask\n",
+        "    q2 = 1 - (1-q_full)/q_err\n",
+        "    mask_pred2_test_above = (np.abs(preds_test2) >= np.quantile(np.abs(preds_test2),   q2))\n",
+        "    mask_pred2_test_below = (np.abs(preds_test2) <= np.quantile(np.abs(preds_test2), 1-q2))\n",
+        "\n",
+        "    true_res_masked_above = true_res.filter(pl.Series(mask_pred_test_err)).filter(pl.Series(mask_pred2_test_above))\n",
+        "    true_res_masked_below = true_res.filter(pl.Series(mask_pred_test_err)).filter(pl.Series(mask_pred2_test_below))\n",
+        "\n",
+        "    score = (np.mean(true_res_masked_above['target_ratio'].to_numpy())) ** (1/opt_params[\"idxAfterPrediction\"])\n",
+        "\n",
+        "    # Log some results\n",
+        "    def quant_dis_in_mask(mask: np.ndarray, q: float) -> float:\n",
+        "        if not mask.any():\n",
+        "            return len(mask)\n",
+        "        return np.quantile(np.abs(np.diff(np.where(mask)[0])), q)\n",
+        "\n",
+        "    fullmask_above = mask_pred_test_err.copy()\n",
+        "    fullmask_below = mask_pred_test_err.copy()\n",
+        "    fullmask_above[mask_pred_test_err] = mask_pred2_test_above\n",
+        "    fullmask_below[mask_pred_test_err] = mask_pred2_test_below\n",
+        "\n",
+        "    logger.info(f\"Trial {trial.number} with params: {opt_params}\")\n",
+        "    logger.info(f\"  q_err: {q_err:.4f}\")\n",
+        "    logger.info(f\"  q2: {q2:.4f}\")\n",
+        "    logger.info(f\"  Duration0: {endtime0 - starttime0}\")\n",
+        "    logger.info(f\"  Duration1: {endtime1 - starttime1}\")\n",
+        "    logger.info(f\"  Duration2: {endtime2 - starttime2}\")\n",
+        "    logger.info(f\"  Val RMSE0 adjusted: {res_dict0['val_rmse']/opt_params['LoadupSamples_time_inc_factor']:.4f}\")\n",
+        "    logger.info(f\"  Val RMSE1 adjusted: {res_dict1['val_rmse']:.4f}\")\n",
+        "    logger.info(f\"  Val RMSE2 adjusted: {res_dict2['val_rmse']/opt_params['LoadupSamples_time_inc_factor']:.4f}\")\n",
+        "    logger.info(f\"  Mean all prediction: {np.mean(true_res['target_ratio'].to_numpy()):.4f}\")\n",
+        "    logger.info(f\"  Mean above prediction: {np.mean(true_res_masked_above['target_ratio'].to_numpy()):.4f}\")\n",
+        "    logger.info(f\"  Mean below prediction: {np.mean(true_res_masked_below['target_ratio'].to_numpy()):.4f}\")\n",
+        "    logger.info(f\"  Quantile 0.99 for distance in mask above: {quant_dis_in_mask(fullmask_above, 0.99)}\")\n",
+        "    logger.info(f\"  Quantile 0.99 for distance in mask below: {quant_dis_in_mask(fullmask_below, 0.99)}\")\n",
+        "    logger.info(f\"  Ratio for quantile-distance-to-length above: {quant_dis_in_mask(fullmask_above, 0.99) / len(fullmask_above):.4f}\")\n",
+        "    logger.info(f\"  Ratio for quantile-distance-to-length below: {quant_dis_in_mask(fullmask_below, 0.99) / len(fullmask_below):.4f}\")\n",
+        "    logger.info(f\"  Score: {score:.4f}\")\n",
+        "\n",
+        "    return score\n",
+        "\n",
+        "optuna.logging.enable_propagation()\n",
+        "sampler = optuna.samplers.TPESampler(n_startup_trials=n_startup_trials)\n",
+        "study = optuna.create_study(\n",
+        "    study_name = studyname,\n",
+        "    storage=\"sqlite:///sandbox_optuna.db\",\n",
+        "    direction=\"maximize\",\n",
+        "    load_if_exists=True,\n",
+        "    sampler=sampler,\n",
+        ")\n",
+        "study.optimize(objective, timeout=studytime)\n",
+        "\n",
+        "logger.info(f\"Best parameters: {study.best_params}\")\n",
+        "logger.info(f\"Best score: {study.best_value}\")\n",
+        "\n",
+        "df: pd.DataFrame = study.trials_dataframe()\n",
+        "logger.info(\"\\nTrials DataFrame:\")\n",
+        "logger.info(df.sort_values(\"value\").to_string())\n",
+        "\n",
+        "param_importances = optuna.importance.get_param_importances(study)\n",
+        "logger.info(\"Parameter Importances:\")\n",
+        "for key, value in param_importances.items():\n",
+        "    logger.info(f\"{key}: {value}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "bc9856fd",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "df.to_parquet(f\"sandbox_lstm_optuna_{formatted_str}.parquet\", index=False)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "511a1e13",
+      "metadata": {},
+      "outputs": [
+        {
+          "ename": "TypeError",
+          "evalue": "LoadupSamples.__init__() got an unexpected keyword argument 'group'",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+            "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 8\u001b[39m\n\u001b[32m      5\u001b[39m best_params[\u001b[33m\"\u001b[39m\u001b[33mLSTM_conv1d_kernel_size\u001b[39m\u001b[33m\"\u001b[39m] = \u001b[32m3\u001b[39m\n\u001b[32m      6\u001b[39m best_params[\u001b[33m\"\u001b[39m\u001b[33mLSTM_num_layers\u001b[39m\u001b[33m\"\u001b[39m] = \u001b[32m1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m8\u001b[39m ls = \u001b[43mLoadupSamples\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m      9\u001b[39m \u001b[43m    \u001b[49m\u001b[43mtrain_start_date\u001b[49m\u001b[43m=\u001b[49m\u001b[43mdatetime\u001b[49m\u001b[43m.\u001b[49m\u001b[43mdate\u001b[49m\u001b[43m(\u001b[49m\u001b[43myear\u001b[49m\u001b[43m=\u001b[49m\u001b[43mbest_params\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43myear_start\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmonth\u001b[49m\u001b[43m=\u001b[49m\u001b[32;43m1\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mday\u001b[49m\u001b[43m=\u001b[49m\u001b[32;43m1\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     10\u001b[39m \u001b[43m    \u001b[49m\u001b[43mtest_dates\u001b[49m\u001b[43m=\u001b[49m\u001b[43m[\u001b[49m\u001b[43meval_date\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     11\u001b[39m \u001b[43m    \u001b[49m\u001b[43mgroup\u001b[49m\u001b[43m=\u001b[49m\u001b[43mstock_group\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     12\u001b[39m \u001b[43m    \u001b[49m\u001b[43mgroup_type\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mTime\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m     13\u001b[39m \u001b[43m    \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m=\u001b[49m\u001b[43mbest_params\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m     14\u001b[39m \u001b[43m)\u001b[49m\n\u001b[32m     15\u001b[39m ls.load_samples(main_path=\u001b[33m\"\u001b[39m\u001b[33m../src/featureAlchemy/bin/\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     17\u001b[39m ls.split_dataset(\n\u001b[32m     18\u001b[39m     start_date=datetime.date(year=best_params[\u001b[33m\"\u001b[39m\u001b[33myear_start\u001b[39m\u001b[33m\"\u001b[39m], month=\u001b[32m1\u001b[39m, day=\u001b[32m1\u001b[39m),\n\u001b[32m     19\u001b[39m     last_train_date=split_date,\n\u001b[32m     20\u001b[39m     last_test_date=eval_date,\n\u001b[32m     21\u001b[39m )\n",
+            "\u001b[31mTypeError\u001b[39m: LoadupSamples.__init__() got an unexpected keyword argument 'group'"
+          ]
+        }
+      ],
+      "source": [
+        "# Run with best parameters\n",
+        "best_params = {**params_default, **study.best_params.copy()}\n",
+        "best_params[\"LSTM_units\"] = 16\n",
+        "best_params[\"LSTM_epochs\"] = 2\n",
+        "best_params[\"LSTM_conv1d_kernel_size\"] = 3\n",
+        "best_params[\"LSTM_num_layers\"] = 1\n",
+        "\n",
+        "ls = LoadupSamples(\n",
+        "    train_start_date=datetime.date(year=best_params[\"year_start\"], month=1, day=1),\n",
+        "    test_dates=[eval_date],\n",
+        "    group=stock_group,\n",
+        "    group_type=\"Time\",\n",
+        "    params=best_params,\n",
+        ")\n",
+        "ls.load_samples(main_path=\"../src/featureAlchemy/bin/\")\n",
+        "\n",
+        "ls.split_dataset(\n",
+        "    start_date=datetime.date(year=best_params[\"year_start\"], month=1, day=1),\n",
+        "    last_train_date=split_date,\n",
+        "    last_test_date=eval_date,\n",
+        ")\n",
+        "\n",
+        "Xtrain = ls.train_Xtime\n",
+        "ytrain = ls.train_ytime\n",
+        "Xtest = ls.test_Xtime\n",
+        "ytest = ls.test_ytime\n",
+        "\n",
+        "Xtrain = Xtrain[:, -best_params[\"timesteps\"]:, :]\n",
+        "Xtest = Xtest[:, -best_params[\"timesteps\"]:, :]\n",
+        "\n",
+        "if best_params[\"is_single_feature\"]:\n",
+        "    Xtrain = Xtrain[:, :, [0]]\n",
+        "    Xtest = Xtest[:, :, [0]]\n",
+        "\n",
+        "mm = MachineModels(best_params)\n",
+        "model_lstm, res_dict = mm.run_LSTM_transformer_torch(Xtrain, ytrain, Xtest, ytest, device=\"cuda\")\n",
+        "preds = mm.predict_LSTM_transformer_torch(model_lstm, Xtest, batch_size=best_params[\"LSTM_batch_size\"], device=\"cuda\")\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7f463c38",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2025-08-16 18:33:38,602 -   Val RSME adjusted: 0.0132\n",
+            "2025-08-16 18:33:38,604 -   Mean all prediction: 1.0010\n",
+            "2025-08-16 18:33:38,605 -   Mean above prediction: 1.0101\n",
+            "2025-08-16 18:33:38,605 -   Mean below prediction: 1.0001\n",
+            "2025-08-16 18:33:38,608 -   Quantile 0.99 in mask above: 450.27999999999884\n",
+            "2025-08-16 18:33:38,609 -   Quantile 0.99 in mask below: 427.0\n",
+            "2025-08-16 18:33:38,611 -   Ratio for quantile to length above: 0.0007\n",
+            "2025-08-16 18:33:38,612 -   Ratio for quantile to length below: 0.0006\n",
+            "2025-08-16 18:33:38,612 -   Score: 1.0025\n"
+          ]
+        }
+      ],
+      "source": [
+        "q = 0.98\n",
+        "mask_pred_above = (preds >= np.quantile(preds, q))\n",
+        "mask_pred_below = (preds <= np.quantile(preds, 1-q))\n",
+        "true_res = ls.meta_pl_test\n",
+        "true_res_masked_above = true_res.filter(pl.Series(mask_pred_above))\n",
+        "true_res_masked_below = true_res.filter(pl.Series(mask_pred_below))\n",
+        "score = (np.mean(true_res_masked_above['target_ratio'].to_numpy())) ** (1/best_params[\"idxAfterPrediction\"])\n",
+        "# Log some results\n",
+        "def quant_dis_in_mask(mask: np.ndarray, q: float) -> int:\n",
+        "    if not mask.any():\n",
+        "        return len(mask)\n",
+        "    return np.quantile(np.abs(np.diff(np.where(mask)[0])), q)\n",
+        "logger.info(f\"  Val RSME adjusted: {res_dict['val_rmse']/best_params['LoadupSamples_time_inc_factor']:.4f}\")\n",
+        "logger.info(f\"  Mean all prediction: {np.mean(true_res['target_ratio'].to_numpy()):.4f}\")\n",
+        "logger.info(f\"  Mean above prediction: {np.mean(true_res_masked_above['target_ratio'].to_numpy()):.4f}\")\n",
+        "logger.info(f\"  Mean below prediction: {np.mean(true_res_masked_below['target_ratio'].to_numpy()):.4f}\")\n",
+        "logger.info(f\"  Quantile 0.99 in mask above: {quant_dis_in_mask(mask_pred_above, 0.99)}\")\n",
+        "logger.info(f\"  Quantile 0.99 in mask below: {quant_dis_in_mask(mask_pred_below, 0.99)}\")\n",
+        "logger.info(f\"  Ratio for quantile to length above: {quant_dis_in_mask(mask_pred_above, 0.99) / len(mask_pred_above):.4f}\")\n",
+        "logger.info(f\"  Ratio for quantile to length below: {quant_dis_in_mask(mask_pred_below, 0.99) / len(mask_pred_below):.4f}\")\n",
+        "logger.info(f\"  Score: {score:.4f}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/src/predictionModule/MachineModels.py
+++ b/src/predictionModule/MachineModels.py
@@ -42,6 +42,17 @@ class MachineModels:
         "LSTM_conv1d": True,
         "LSTM_conv1d_kernel_size": 3,
         "LSTM_loss": "mse",
+
+        "LSTM_transformer_before": False,
+        "LSTM_transformer_after": False,
+        "LSTM_tf_d_model": 0,
+        "LSTM_tf_nhead": 4,
+        "LSTM_tf_num_layers_before": 1,
+        "LSTM_tf_num_layers_after": 1,
+        "LSTM_tf_dim_feedforward": 128,
+        "LSTM_tf_dropout": 0.1,
+        "LSTM_tf_positional_encoding": True,
+        "LSTM_tf_pool": "last",
         
         "LGB_num_boost_round": 1500,
         "LGB_lambda_l1": 0.04614242128149404,
@@ -612,8 +623,197 @@ class MachineModels:
                 X_batch = X_batch[0].to(device)
                 preds = model(X_batch).squeeze().cpu().numpy()
                 predictions.append(preds)
-        
+
         return np.concatenate(predictions, axis=0)
+
+    def __run_lstm_transformer_torch(self,
+            X_train: np.ndarray,
+            y_train: np.ndarray,
+            X_test: np.ndarray = None,
+            y_test: np.ndarray = None,
+            device: str = 'cpu'
+        ) -> tuple[torch.nn.Module, dict]:
+        lstm_units = self.params['LSTM_units']
+        num_layers = self.params['LSTM_num_layers']
+        dropout = self.params['LSTM_dropout']
+        recurrent_dropout = self.params['LSTM_recurrent_dropout']
+        learning_rate = self.params['LSTM_learning_rate']
+        optimizer_name = self.params['LSTM_optimizer']
+        bidirectional = self.params['LSTM_bidirectional']
+        batch_size = self.params['LSTM_batch_size']
+        epochs = self.params['LSTM_epochs']
+        loss_name = self.params['LSTM_loss']
+        l1 = self.params.get('LSTM_l1', 0.0)
+        l2 = self.params.get('LSTM_l2', 0.0)
+        inter_dropout = self.params.get('LSTM_inter_dropout', 0.0)
+        noise_std = self.params.get('LSTM_input_gaussian_noise', 0.0)
+        use_conv1d = self.params.get('LSTM_conv1d', False)
+        conv_kernel = self.params.get('LSTM_conv1d_kernel_size', 3)
+
+        transformer_before = self.params.get('LSTM_transformer_before', False)
+        transformer_after = self.params.get('LSTM_transformer_after', False)
+        num_layers_before = self.params.get('LSTM_tf_num_layers_before', 1)
+        num_layers_after = self.params.get('LSTM_tf_num_layers_after', 1)
+        if num_layers_before == 0:
+            transformer_before = False
+        if num_layers_after == 0:
+            transformer_after = False
+        tf_d_model = self.params.get('LSTM_tf_d_model', 0)
+        if tf_d_model in (0, None):
+            tf_d_model = X_train.shape[-1]
+
+        train_ds = TensorDataset(
+            torch.tensor(X_train, dtype=torch.float32),
+            torch.tensor(y_train, dtype=torch.float32)
+        )
+        val_ds = TensorDataset(
+            torch.tensor(X_test, dtype=torch.float32),
+            torch.tensor(y_test, dtype=torch.float32)
+        )
+        train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
+        val_loader = DataLoader(val_ds, batch_size=batch_size)
+
+        model = LSTMTransformer_Torch(
+            input_size=X_train.shape[-1],
+            lstm_units=lstm_units,
+            num_layers=num_layers,
+            dropout=dropout,
+            recurrent_dropout=recurrent_dropout,
+            bidirectional=bidirectional,
+            l1=l1,
+            l2=l2,
+            use_conv1d=use_conv1d,
+            conv_kernel=conv_kernel,
+            noise_std=noise_std,
+            inter_dropout=inter_dropout,
+            transformer_before=transformer_before,
+            transformer_after=transformer_after,
+            tf_d_model=tf_d_model,
+            tf_nhead=self.params.get('LSTM_tf_nhead', 4),
+            tf_num_layers_before=num_layers_before,
+            tf_num_layers_after=num_layers_after,
+            tf_dim_feedforward=self.params.get('LSTM_tf_dim_feedforward', 128),
+            tf_dropout=self.params.get('LSTM_tf_dropout', 0.1),
+            tf_positional_encoding=self.params.get('LSTM_tf_positional_encoding', True),
+            tf_pool=self.params.get('LSTM_tf_pool', 'last'),
+        ).to(device)
+
+        def quantile_loss(q):
+            def loss_fn(y_pred, y_true):
+                e = y_true - y_pred
+                return torch.mean(torch.max(q * e, (q - 1) * e))
+            return loss_fn
+
+        def r2_metric(y_pred, y_true):
+            ss_res = torch.sum((y_true - y_pred) ** 2)
+            ss_tot = torch.sum((y_true - torch.mean(y_true)) ** 2)
+            return 1 - ss_res / (ss_tot + 1e-6)
+
+        def neg_r2_loss(y_pred, y_true):
+            return -r2_metric(y_pred, y_true)
+
+        if loss_name == 'mse':
+            criterion = nn.MSELoss()
+        elif loss_name == 'r2':
+            criterion = lambda pred, true: neg_r2_loss(pred, true)
+        else:
+            q = int(loss_name.split('_')[1]) / 10.0
+            criterion = quantile_loss(q)
+
+        optimizer = optim.Adam(
+            model.parameters(), lr=learning_rate, weight_decay=l2
+        )
+        if optimizer_name == 'rmsprop':
+            optimizer = optim.RMSprop(
+                model.parameters(), lr=learning_rate, weight_decay=l2
+            )
+        scheduler = optim.lr_scheduler.ReduceLROnPlateau(
+            optimizer, factor=0.5, patience=2
+        )
+
+        best_rmse, wait = float('inf'), 0
+        start_time = time.time()
+
+        for epoch in trange(epochs, desc='Epochs'):
+            model.train()
+            sum_sq_error = 0.0
+            total_samples = 0
+
+            for X_batch, y_batch in tqdm(train_loader, desc='Training', leave=False):
+                X_batch, y_batch = X_batch.to(device), y_batch.to(device)
+                optimizer.zero_grad()
+
+                preds = model(X_batch).squeeze()
+                loss = criterion(preds, y_batch)
+                if l1 > 0:
+                    loss = loss + l1 * sum(p.abs().sum() for p in model.parameters())
+                loss.backward()
+                optimizer.step()
+
+                se = ((preds.detach() - y_batch) ** 2).sum().item()
+                sum_sq_error += se
+                total_samples += y_batch.numel()
+
+                if time.time() - start_time > 3600:
+                    break
+
+            train_rmse = (sum_sq_error / total_samples) ** 0.5
+
+            model.eval()
+            val_rmses = []
+            with torch.no_grad():
+                for X_batch, y_batch in tqdm(val_loader, desc='Validation', leave=False):
+                    X_batch, y_batch = X_batch.to(device), y_batch.to(device)
+                    preds = model(X_batch).squeeze()
+                    mse = nn.MSELoss()(preds, y_batch)
+                    val_rmses.append(torch.sqrt(mse).item())
+            val_rmse = sum(val_rmses) / len(val_rmses)
+
+            logger.info(f"Epoch {epoch+1}/{epochs} — "
+                f"Train RMSE: {train_rmse:.4f} — "
+                f"Validation RMSE: {val_rmse:.4f}")
+
+            scheduler.step(val_rmse)
+
+            if val_rmse < best_rmse:
+                best_rmse, wait = val_rmse, 0
+                best_state = model.state_dict()
+            else:
+                wait += 1
+                if wait >= 3:
+                    break
+            if time.time() - start_time > 3600:
+                break
+
+        model.load_state_dict(best_state)
+        return model, {'val_rmse': best_rmse, 'history': None}
+
+    def run_LSTM_transformer_torch(self,
+            X_train: np.ndarray,
+            y_train: np.ndarray,
+            X_test: np.ndarray = None,
+            y_test: np.ndarray = None,
+            device: str = 'cpu'
+        ) -> tuple[torch.nn.Module, dict]:
+        return self.__run_lstm_transformer_torch(X_train, y_train, X_test, y_test, device)
+
+    def predict_LSTM_transformer_torch(self,
+            model: torch.nn.Module,
+            X: np.ndarray,
+            batch_size: int = 2**10,
+            device: str = 'cpu'
+        ) -> np.ndarray:
+        model.eval()
+        X_tensor = torch.tensor(X, dtype=torch.float32).to(device)
+        dataset = TensorDataset(X_tensor)
+        loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
+        preds_list = []
+        with torch.no_grad():
+            for X_batch in loader:
+                X_batch = X_batch[0].to(device)
+                preds = model(X_batch).squeeze().cpu().numpy()
+                preds_list.append(preds)
+        return np.concatenate(preds_list, axis=0)
 
 class LSTM_Torch(nn.Module):
     def __init__(self, 
@@ -669,3 +869,167 @@ class LSTM_Torch(nn.Module):
         if self.dropout:
             out_last = self.dropout(out_last)
         return self.output(out_last)
+
+
+class PositionalEncoding(nn.Module):
+    def __init__(self, d_model, max_len: int = 5000):
+        super().__init__()
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-np.log(10000.0) / d_model))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.register_buffer('pe', pe)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.pe[:, :x.size(1)]
+
+
+class LSTMTransformer_Torch(nn.Module):
+    def __init__(self,
+            input_size,
+            lstm_units,
+            num_layers,
+            dropout,
+            recurrent_dropout,
+            bidirectional,
+            l1=0.0,
+            l2=0.0,
+            use_conv1d=False,
+            conv_kernel=3,
+            noise_std=0.0,
+            inter_dropout=0.0,
+            transformer_before=False,
+            transformer_after=False,
+            tf_d_model=0,
+            tf_nhead=4,
+            tf_num_layers_before=1,
+            tf_num_layers_after=1,
+            tf_dim_feedforward=128,
+            tf_dropout=0.1,
+            tf_positional_encoding=True,
+            tf_pool="last",
+        ):
+        super().__init__()
+        self.use_conv1d = use_conv1d
+        self.noise_std = noise_std
+        self.inter_dropout = inter_dropout
+
+        if use_conv1d:
+            self.conv1d = nn.Conv1d(
+                in_channels=input_size,
+                out_channels=lstm_units,
+                kernel_size=conv_kernel,
+                padding=conv_kernel // 2,
+            )
+            input_size_after = lstm_units
+        else:
+            input_size_after = input_size
+
+        self.transformer_before = transformer_before
+        self.transformer_after = transformer_after
+
+        if transformer_before:
+            d_model = tf_d_model if tf_d_model > 0 else input_size_after
+            self.pre_proj = nn.Linear(input_size_after, d_model) if input_size_after != d_model else None
+            enc_layer = nn.TransformerEncoderLayer(
+                d_model=d_model,
+                nhead=tf_nhead,
+                dim_feedforward=tf_dim_feedforward,
+                dropout=tf_dropout,
+                batch_first=True,
+            )
+            self.pre_tf = nn.TransformerEncoder(enc_layer, num_layers=tf_num_layers_before)
+            self.pos_enc_before = PositionalEncoding(d_model) if tf_positional_encoding else None
+            lstm_input_size = d_model
+        else:
+            self.pre_proj = None
+            self.pre_tf = None
+            self.pos_enc_before = None
+            lstm_input_size = input_size_after
+
+        self.lstm = nn.LSTM(
+            input_size=lstm_input_size,
+            hidden_size=lstm_units,
+            num_layers=num_layers,
+            dropout=dropout if num_layers > 1 else 0.0,
+            bidirectional=bidirectional,
+            batch_first=True,
+        )
+
+        self.dropout = nn.Dropout(inter_dropout) if inter_dropout > 0 else None
+
+        lstm_out_dim = lstm_units * (2 if bidirectional else 1)
+
+        if transformer_after:
+            d_model_after = tf_d_model if tf_d_model > 0 else lstm_out_dim
+            self.post_proj = nn.Linear(lstm_out_dim, d_model_after) if lstm_out_dim != d_model_after else None
+            enc_layer_a = nn.TransformerEncoderLayer(
+                d_model=d_model_after,
+                nhead=tf_nhead,
+                dim_feedforward=tf_dim_feedforward,
+                dropout=tf_dropout,
+                batch_first=True,
+            )
+            self.post_tf = nn.TransformerEncoder(enc_layer_a, num_layers=tf_num_layers_after)
+            self.pos_enc_after = PositionalEncoding(d_model_after) if tf_positional_encoding else None
+            final_dim = d_model_after
+        else:
+            self.post_proj = None
+            self.post_tf = None
+            self.pos_enc_after = None
+            final_dim = lstm_out_dim
+
+        self.pool = tf_pool
+        if tf_pool == 'attn':
+            self.attn_layer = nn.Linear(final_dim, final_dim)
+            self.attn_vector = nn.Linear(final_dim, 1)
+        else:
+            self.attn_layer = None
+            self.attn_vector = None
+
+        self.output = nn.Linear(final_dim, 1)
+
+    def forward(self, x):
+        if self.noise_std > 0:
+            x = x + torch.randn_like(x) * self.noise_std
+        if self.use_conv1d:
+            x = x.transpose(1, 2)
+            x = self.conv1d(x)
+            x = x.transpose(1, 2)
+
+        if self.transformer_before:
+            if self.pre_proj is not None:
+                x = self.pre_proj(x)
+            if self.pos_enc_before is not None:
+                x = self.pos_enc_before(x)
+            x = self.pre_tf(x)
+
+        out, _ = self.lstm(x)
+        if self.dropout:
+            out = self.dropout(out)
+
+        if self.transformer_after:
+            x2 = out
+            if self.post_proj is not None:
+                x2 = self.post_proj(x2)
+            if self.pos_enc_after is not None:
+                x2 = self.pos_enc_after(x2)
+            x2 = self.post_tf(x2)
+        else:
+            x2 = out
+
+        if self.pool == 'last':
+            pooled = x2[:, -1, :]
+        elif self.pool == 'mean':
+            pooled = x2.mean(dim=1)
+        elif self.pool == 'attn':
+            attn = torch.tanh(self.attn_layer(x2))
+            attn = self.attn_vector(attn).squeeze(-1)
+            attn = torch.softmax(attn, dim=1)
+            pooled = torch.bmm(attn.unsqueeze(1), x2).squeeze(1)
+        else:
+            raise ValueError("Invalid pool option")
+
+        return self.output(pooled)


### PR DESCRIPTION
## Summary
- Extend MachineModels with optional Transformer blocks before/after the LSTM and matching train/predict APIs
- Introduce `LSTMTransformer_Torch` model supporting positional encoding, pooling modes and attention
- Add Optuna notebook `sandbox_lstm_transformer_optuna.ipynb` to tune new Transformer hyperparameters

## Testing
- `pytest` *(fails: Attributes of DataFrame.iloc[:, 0] (dtype mismatch))*

------
https://chatgpt.com/codex/tasks/task_e_68a5fd176a308325bd4906fd569fef56