### PR TITLE
Finalize Optuna infrastructure with tests

### DIFF
--- a/runOptimize.py
+++ b/runOptimize.py
@@ -1,67 +1,88 @@
 import datetime
+import logging
+from pathlib import Path
 
-from src.hyperparameterTuning.OptunaTuning import OptunaTuning
-from src.predictionModule.LoadupSamples import LoadupSamples
 from src.hyperparameterTuning.OptunaClient import OptunaClient
+from src.hyperparameterTuning.OptunaTuning import OptunaTuning
 from src.hyperparameterTuning.StratFilterSamples import StratFilterSamples
+from src.predictionModule.LoadupSamples import LoadupSamples
+
 import treetimeParams
 
 
 stock_group = "group_finanTo2011"
 stock_group_short = stock_group.replace("group_", "")
 
-import logging
 formatted_date = datetime.datetime.now().strftime("%d%b%y_%H%M").lower()
 logging.basicConfig(
-    filename=f'logs/output_optuna_TreeTime_{stock_group_short}_{formatted_date}.log',
-    level=logging.DEBUG,
-    format='%(asctime)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M'
+    filename=f"logs/output_optuna_TreeTime_{stock_group_short}_{formatted_date}.log",
+    level=logging.INFO,
+    format="%(asctime)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M",
 )
 logger = logging.getLogger(__name__)
 
 params = treetimeParams.params
+logger.info("Params: %s", params)
 
-logger.info(f" Params: {params}")
 
-###########################
-## HYPERPARAMETER TUNING ##
-###########################
-if __name__ == "__main__":
-    # Static config
+def main() -> None:
     optuna_study_name = f"Optuna_{stock_group_short}_{formatted_date}"
     optuna_duration = 60 * 60 * 10
-    global_start_date = datetime.date(2014, 1, 1)     # earliest data
-    final_eval_date   = datetime.date(2025, 7, 15)    # last date you want to consider cutoffs up to
-    test_horizon_days = 7                            # days after train cutoff for test slice
+    global_start_date = datetime.date(2014, 1, 1)
+    final_eval_date = datetime.date(2025, 7, 15)
+    test_horizon_days = 7
     n_splits = 200
+    n_startup_trials = max(20, n_splits // 5)
+    training_window_days = params.get("Treetime_LSTM_days_to_train", 365)
 
-    # Pre-load once
     test_dates = [final_eval_date - datetime.timedelta(days=i) for i in range(test_horizon_days)][::-1]
+
     ls = LoadupSamples(
         train_start_date=global_start_date,
-        test_dates=test_dates,  # will be overridden in split loop; kept for init
-        group=stock_group,
-        group_type='Tree',
+        test_dates=test_dates,
+        treegroup=stock_group,
         params=params,
     )
     ls.load_samples()
-    
-    # Setup Optuna client
+
     optuna_client = OptunaClient(
-        study_name=optuna_study_name,
-        n_trials=n_splits,
-        timeout=optuna_duration
+        ls=ls,
+        n_splits=n_splits,
+        n_test_days=test_horizon_days,
+        n_training_days=training_window_days,
     )
 
-    # Setup strategy
-    strategy = StratFilterSamples(filter_method="lincomb")
+    strategy_name = params.get("TreeTime_FilterSamples_method", "lincomb")
+    strategy = StratFilterSamples(filter_method=strategy_name)
 
-    # Create objective function
+    # Log the selected split dates for traceability
+    try:
+        optuna_client.get_split_dates(
+            final_split_date=final_eval_date,
+            start_train_date=global_start_date,
+        )
+    except ValueError as exc:
+        logger.warning("Unable to sample split dates for logging: %s", exc)
+
     objective = optuna_client.make_objective(strategy=strategy)
 
-    # Run Optuna
     optuna_tuner = OptunaTuning(
-        client=optuna_client,
-        objective=objective
+        studyname=optuna_study_name,
+        n_startup_trials=n_startup_trials,
+        studytime=optuna_duration,
+        objective=objective,
+        direction="maximize",
     )
+
+    study, df = optuna_tuner.run()
+
+    Path("outputs").mkdir(exist_ok=True)
+    output_path = Path("outputs") / f"optuna_results_{stock_group_short}_{formatted_date}.parquet"
+    df.to_parquet(output_path)
+    logger.info("Saved Optuna results to %s", output_path)
+    logger.info("Optuna study finished with %s completed trials.", len(df))
+
+
+if __name__ == "__main__":
+    main()

--- a/runOptimize.py
+++ b/runOptimize.py
@@ -9,13 +9,13 @@ from src.predictionModule.LoadupSamples import LoadupSamples
 
 import treetimeParams
 
-
-stock_group = "group_finanTo2011"
-stock_group_short = stock_group.replace("group_", "")
+timegroup = "group_regOHLCV_over5years"
+stock_group = "group_debug"
+stock_group_short = '_'.join(stock_group.split('_')[1:])
 
 formatted_date = datetime.datetime.now().strftime("%d%b%y_%H%M").lower()
 logging.basicConfig(
-    filename=f"logs/output_optuna_TreeTime_{stock_group_short}_{formatted_date}.log",
+    filename=f"logs/output_optuna_{stock_group_short}_{formatted_date}.log",
     level=logging.INFO,
     format="%(asctime)s - %(message)s",
     datefmt="%Y-%m-%d %H:%M",
@@ -25,16 +25,20 @@ logger = logging.getLogger(__name__)
 params = treetimeParams.params
 logger.info("Params: %s", params)
 
+strategy_name = params.get("TreeTime_FilterSamples_method", "taylor")
+strategy = StratFilterSamples(filter_method=strategy_name)
+logger.info("Using strategy: %s", StratFilterSamples.__name__)
 
 def main() -> None:
     optuna_study_name = f"Optuna_{stock_group_short}_{formatted_date}"
-    optuna_duration = 60 * 60 * 10
-    global_start_date = datetime.date(2014, 1, 1)
+    optuna_duration = 60 * 60 * 1
+    global_start_date = datetime.date(2016, 1, 1)
     final_eval_date = datetime.date(2025, 7, 15)
     test_horizon_days = 7
     n_splits = 200
-    n_startup_trials = max(20, n_splits // 5)
-    training_window_days = params.get("Treetime_LSTM_days_to_train", 365)
+    n_startup_trials = max(10, n_splits // 5)
+    training_window_days = 900
+    direction = "maximize"
 
     test_dates = [final_eval_date - datetime.timedelta(days=i) for i in range(test_horizon_days)][::-1]
 
@@ -42,6 +46,7 @@ def main() -> None:
         train_start_date=global_start_date,
         test_dates=test_dates,
         treegroup=stock_group,
+        timegroup=timegroup,
         params=params,
     )
     ls.load_samples()
@@ -52,9 +57,6 @@ def main() -> None:
         n_test_days=test_horizon_days,
         n_training_days=training_window_days,
     )
-
-    strategy_name = params.get("TreeTime_FilterSamples_method", "lincomb")
-    strategy = StratFilterSamples(filter_method=strategy_name)
 
     # Log the selected split dates for traceability
     try:
@@ -72,7 +74,7 @@ def main() -> None:
         n_startup_trials=n_startup_trials,
         studytime=optuna_duration,
         objective=objective,
-        direction="maximize",
+        direction=direction,
     )
 
     study, df = optuna_tuner.run()

--- a/src/hyperparameterTuning/BaseStrategy.py
+++ b/src/hyperparameterTuning/BaseStrategy.py
@@ -1,37 +1,36 @@
 import optuna
 from abc import ABC, abstractmethod
 
+
 class BaseStrategy(ABC):
-    def __init__(self):
-        pass
+    """Interface for Optuna optimisation strategies."""
 
     @abstractmethod
     def sample_params(self, trial: optuna.Trial) -> dict:
         """Sample hyperparameters using the provided Optuna trial object."""
-        pass
 
     @abstractmethod
-    def score(self, 
+    def score(
+        self,
         Xtr_tree,
-        Xtr_time, 
-        ytr_tree, 
+        Xtr_time,
+        ytr_tree,
         Xte_tree,
-        Xte_time, 
+        Xte_time,
         yte_tree,
-        params: dict
+        params: dict,
     ) -> float:
         """Evaluate the model with the given parameters and return a score."""
-        pass
 
     @abstractmethod
-    def mask_precompute(self, 
+    def mask_precompute(
+        self,
         Xtr_tree,
-        Xtr_time, 
-        ytr_tree, 
+        Xtr_time,
+        ytr_tree,
         Xte_tree,
-        Xte_time, 
+        Xte_time,
         yte_tree,
-        params: dict
-    ) -> float:
-        """Evaluate the model with the given parameters and return a score."""
-        pass
+        params: dict,
+    ) -> dict:
+        """Pre-compute information required before scoring and return it as a dict."""

--- a/src/hyperparameterTuning/OptunaClient.py
+++ b/src/hyperparameterTuning/OptunaClient.py
@@ -197,7 +197,7 @@ class OptunaClient:
             if not vals:
                 return float("-inf")
 
-            vals_log = np.log1p(np.asarray(vals))
+            vals_log = np.log(np.asarray(vals))
             if len(vals) < (len(scores) // 2):
                 return 0.0
             return float(np.mean(vals_log))

--- a/src/hyperparameterTuning/OptunaClient.py
+++ b/src/hyperparameterTuning/OptunaClient.py
@@ -1,136 +1,222 @@
-import optuna
 import datetime
+import logging
 import random
-import polars as pl
+from typing import Callable, List, Optional, Sequence, Tuple
+
 import numpy as np
+import optuna
 
 from src.common.DataFrameTimeOperations import DataFrameTimeOperations as dfta
-from src.predictionModule.LoadupSamples import LoadupSamples
 from src.hyperparameterTuning.BaseStrategy import BaseStrategy
-from src.predictionModule.MachineModels import MachineModels
+from src.predictionModule.LoadupSamples import LoadupSamples
 
-import logging
 logger = logging.getLogger(__name__)
 
+
+SlicePair = Tuple[slice, slice]
+
+
 class OptunaClient:
-    def __init__(self, ls:LoadupSamples, n_splits: int, n_test_days: int, n_training_days: int):
-        self.__extract_arrays(ls)
+    """Utility orchestrating Optuna optimisation on top of ``LoadupSamples``."""
+
+    def __init__(
+        self,
+        ls: LoadupSamples,
+        n_splits: int,
+        n_test_days: int,
+        n_training_days: int,
+        *,
+        rng: Optional[random.Random] = None,
+        model_cls: Optional[type] = None,
+    ) -> None:
+        self._extract_training_arrays(ls)
         self.n_splits = n_splits
         self.n_test_days = n_test_days
         self.n_training_days = n_training_days
+        self._rng = rng if rng is not None else random.Random()
+        if model_cls is None:
+            from src.predictionModule.MachineModels import MachineModels as _MachineModels
 
+            model_cls = _MachineModels
+        self._model_cls = model_cls
+
+    # ------------------------------------------------------------------
+    # Split helpers
+    # ------------------------------------------------------------------
     def get_split_dates(
         self,
         final_split_date: datetime.date,
-        start_train_date: datetime.date
-    ):
-        start = start_train_date + datetime.timedelta(days=self.n_training_days-1)
-        end   = final_split_date - datetime.timedelta(days=self.n_test_days)
+        start_train_date: datetime.date,
+    ) -> List[datetime.date]:
+        """Return random split dates respecting the provided constraints."""
+
+        start = start_train_date + datetime.timedelta(days=self.n_training_days - 1)
+        end = final_split_date - datetime.timedelta(days=self.n_test_days)
+        if start > end:
+            raise ValueError("Training window does not fit between start and end dates.")
+
         eligible = [
-            start + datetime.timedelta(days=i) 
-                for i in range((end - start).days + 1) 
-                    if (start + datetime.timedelta(days=i)).weekday() < 5
+            start + datetime.timedelta(days=i)
+            for i in range((end - start).days + 1)
+            if (start + datetime.timedelta(days=i)).weekday() < 5
         ]
-        split_dates = sorted(random.sample(eligible, self.n_splits))
+        if len(eligible) < self.n_splits:
+            raise ValueError(
+                f"Too few eligible split dates ({len(eligible)}) for n_splits={self.n_splits}."
+            )
 
-        # Logging
+        split_dates = sorted(self._rng.sample(eligible, self.n_splits))
+
         for date in split_dates:
-            logger.info(f"  Split date: {date}")
-        logger.info(f"  n_reruns: {self.n_splits}")
-        logger.info(f"  max_training_days: {self.n_training_days}")
-        logger.info(f"  n_testdays: {self.n_test_days}")
-        logger.info(f"  start_train_date: {start_train_date}")
-        logger.info(f"  final_split_date: {final_split_date}")
+            logger.info("  Split date: %s", date)
+        logger.info("  n_reruns: %s", self.n_splits)
+        logger.info("  max_training_days: %s", self.n_training_days)
+        logger.info("  n_testdays: %s", self.n_test_days)
+        logger.info("  start_train_date: %s", start_train_date)
+        logger.info("  final_split_date: %s", final_split_date)
 
-    def get_pivots(self):
-        dates_tr = self.meta_train['date'].unique().sort()
-        dates_tr_idx = dfta(self.meta_train, 'date').getNextLowerOrEqualIndices(dates_tr)
+        return split_dates
+
+    def get_pivots(self) -> List[int]:
+        """Sample pivot indices (last training day) used for slicing."""
+
+        dates_tr = self.meta_train["date"].unique().sort()
+        dates_tr_idx = dfta(self.meta_train, "date").getNextLowerOrEqualIndices(dates_tr)
 
         N = len(dates_tr_idx)
-        lo = self.n_training_days - 1                    # min pivot (last train index)
-        hi = N - self.n_test_days - 2              # max pivot
+        lo = self.n_training_days - 1
+        hi = N - self.n_test_days - 2
         eligible = list(range(lo, hi + 1))
-        assert len(eligible) >= self.n_splits, f"Too few eligible pivots ({len(eligible)}) for n_splits={self.n_splits}"
-        pivots = sorted(random.sample(eligible, self.n_splits))
+        if len(eligible) < self.n_splits:
+            raise ValueError(
+                f"Too few eligible pivots ({len(eligible)}) for n_splits={self.n_splits}."
+            )
 
+        pivots = sorted(self._rng.sample(eligible, self.n_splits))
         for p in pivots:
-            logger.info(f"  Pivot {p}: Date {dates_tr[p]}")
+            logger.info("  Pivot %s: Date %s", p, dates_tr[p])
+        return pivots
 
-    def get_slices(self):
+    def get_slices(self) -> List[SlicePair]:
+        """Return list of (train_slice, test_slice) pairs for cross-validation."""
+
         pivots = self.get_pivots()
+        dates_tr = self.meta_train["date"].unique().sort()
+        dates_tr_idx = dfta(self.meta_train, "date").getNextLowerOrEqualIndices(dates_tr)
 
-        dates_tr = self.meta_train['date'].unique().sort()
-        dates_tr_idx = dfta(self.meta_train, 'date').getNextLowerOrEqualIndices(dates_tr)
-
-        slices = [None] * self.n_splits
-        for i in range(self.n_splits):
-            p = pivots[i]
-
+        slices: List[SlicePair] = [None] * self.n_splits  # type: ignore[list-item]
+        for i, p in enumerate(pivots):
             tr_l_idx = dates_tr_idx[p - self.n_training_days + 1]
             tr_u_idx = dates_tr_idx[p + 1] - 1
             te_l_idx = dates_tr_idx[p + 1]
             te_u_idx = dates_tr_idx[p + self.n_test_days + 1] - 1
 
-            s_tr = slice(tr_l_idx, tr_u_idx)
-            s_te = slice(te_l_idx, te_u_idx)
+            s_tr = slice(tr_l_idx, tr_u_idx + 1)
+            s_te = slice(te_l_idx, te_u_idx + 1)
             slices[i] = (s_tr, s_te)
 
         return slices
-    
-    def __extract_arrays(self, ls:LoadupSamples):
-        self.Xtr_tree = ls.train_Xtree
-        self.ytr_tree = ls.train_ytree
-        self.Xte_tree = ls.test_Xtree
-        self.yte_tree = ls.test_ytree
 
-        self.Xtr_time = ls.train_Xtime
-        self.ytr_time = ls.train_ytime
-        self.Xte_time  = ls.test_Xtime
-        self.yte_time  = ls.test_ytime
+    # ------------------------------------------------------------------
+    # Objective helper
+    # ------------------------------------------------------------------
+    def make_objective(self, strategy: BaseStrategy) -> Callable[[optuna.Trial], float]:
+        """Create an Optuna objective callable using the provided strategy."""
 
-        self.treenames   = ls.featureTreeNames
-        self.timenames   = ls.featureTimeNames
-        self.meta_train  = ls.meta_pl_train
-        self.meta_test   = ls.meta_pl_test
-    
-    def make_objective(self, 
-            strategy: BaseStrategy,
-        ) -> callable[[optuna.Trial], float]:
         slices = self.get_slices()
+
+        def _slice_optional(arr: Optional[Sequence], sl: slice):
+            if arr is None:
+                return None
+            return arr[sl]
 
         def objective(trial: optuna.Trial) -> float:
             opt_params = strategy.sample_params(trial)
-            logger.info(f"Trial {trial.number} with params: {opt_params}")
+            logger.info("Trial %s with params: %s", trial.number, opt_params)
 
-            scores = []
-            mm = MachineModels(params=opt_params)
-            for i in range(self.n_splits):
-                s_tr, s_te = slices[i]
+            scores: List[float] = []
+            mm = self._model_cls(params=opt_params)
 
-                score_params = {
+            for s_tr, s_te in slices:
+                Xtr_tree = self.X_tree[s_tr]
+                ytr_tree = self.y_tree[s_tr]
+                Xte_tree = self.X_tree[s_te]
+                yte_tree = self.y_tree[s_te]
+
+                Xtr_time = _slice_optional(self.X_time, s_tr)
+                ytr_time = _slice_optional(self.y_time, s_tr)
+                Xte_time = _slice_optional(self.X_time, s_te)
+                yte_time = _slice_optional(self.y_time, s_te)
+
+                meta_train_slice = self.meta_train[s_tr] if self.meta_train is not None else None
+                meta_test_slice = self.meta_train[s_te] if self.meta_train is not None else None
+
+                base_params = {
                     "mm": mm,
+                    "treenames": self.treenames,
+                    "timenames": self.timenames,
+                    "meta_train": meta_train_slice,
+                    "meta_test": meta_test_slice,
                 }
-                sc = strategy.score(
-                    self.Xtr_tree[s_tr],
-                    self.Xtr_time[s_tr],
-                    self.ytr_tree[s_tr],
-                    self.Xte_tree[s_te],
-                    self.Xte_time[s_te],
-                    self.yte_tree[s_te],
-                    params = score_params
-                )
 
-                #except Exception as e:
-                #    logger.info(f"Exception during scoring: {e}")
-                #    trial.should_prune()
-                #    sc = metric(1.0)
-                scores.append(sc)
+                try:
+                    mask_params = strategy.mask_precompute(
+                        Xtr_tree,
+                        Xtr_time,
+                        ytr_tree,
+                        Xte_tree,
+                        Xte_time,
+                        yte_tree,
+                        params=base_params,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.exception("mask_precompute failed: %s", exc)
+                    mask_params = {}
+
+                score_params = {**base_params, **(mask_params or {})}
+
+                try:
+                    sc = strategy.score(
+                        Xtr_tree,
+                        Xtr_time,
+                        ytr_tree,
+                        Xte_tree,
+                        Xte_time,
+                        yte_tree,
+                        params=score_params,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.exception("Score computation failed: %s", exc)
+                    trial.should_prune()
+                    sc = np.nan
+
+                scores.append(float(sc) if sc is not None else np.nan)
 
             vals = [v for v in scores if np.isfinite(v)]
-            logger.info(f"Scores per splits: {vals}")
-            vals = np.array(vals)
-            vals_log = np.log(1.0 + vals)
-            if len(vals) < (len(scores)//2):
+            logger.info("Scores per split: %s", vals)
+            if not vals:
+                return float("-inf")
+
+            vals_log = np.log1p(np.asarray(vals))
+            if len(vals) < (len(scores) // 2):
                 return 0.0
-            return float(np.mean(vals_log)) if len(vals_log) else -np.inf
+            return float(np.mean(vals_log))
+
         return objective
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _extract_training_arrays(self, ls: LoadupSamples) -> None:
+        """Extract training arrays and metadata from ``LoadupSamples``."""
+
+        self.X_tree = ls.train_Xtree
+        self.y_tree = ls.train_ytree
+        self.X_time = ls.train_Xtime
+        self.y_time = ls.train_ytime
+        self.treenames = ls.featureTreeNames
+        self.timenames = ls.featureTimeNames
+        self.meta_train = ls.meta_pl_train
+
+        if self.meta_train is None:
+            raise ValueError("LoadupSamples must provide training metadata for Optuna splits.")

--- a/src/hyperparameterTuning/OptunaTuning.py
+++ b/src/hyperparameterTuning/OptunaTuning.py
@@ -1,32 +1,38 @@
+import logging
+from typing import Callable, Tuple
+
 import optuna
 import pandas as pd
 import polars as pl
 
-import logging
 logger = logging.getLogger(__name__)
 
-class OptunaTuning():
-    storage_name = "sqlite:///sandbox_optuna.db"
 
-    def __init__(self,
-            studyname: str,
-            n_startup_trials: int,
-            studytime: int,
-            objective: callable[[optuna.Trial], float],
-            direction: str,
-        ):
+class OptunaTuning:
+    """Run and analyse an Optuna study."""
+
+    def __init__(
+        self,
+        studyname: str,
+        n_startup_trials: int,
+        studytime: int,
+        objective: Callable[[optuna.Trial], float],
+        direction: str = "maximize",
+        storage_name: str = "sqlite:///sandbox_optuna.db",
+    ) -> None:
         self.studyname = studyname
         self.n_startup_trials = n_startup_trials
         self.studytime = studytime
         self.objective = objective
         self.direction = direction
+        self.storage_name = storage_name
 
-    def run(self) -> tuple[optuna.study.Study, pd.DataFrame]:
-        logger.info(f"Starting Optuna study: {self.studyname}")
+    def run(self) -> Tuple[optuna.study.Study, pd.DataFrame]:
+        logger.info("Starting Optuna study: %s", self.studyname)
         optuna.logging.enable_propagation()
-        sampler = optuna.samplers.TPESampler(
-            n_startup_trials=self.n_startup_trials
-        )
+        optuna.logging.disable_default_handler()
+
+        sampler = optuna.samplers.TPESampler(n_startup_trials=self.n_startup_trials)
         study = optuna.create_study(
             study_name=self.studyname,
             storage=self.storage_name,
@@ -34,44 +40,44 @@ class OptunaTuning():
             load_if_exists=True,
             sampler=sampler,
         )
-        study.optimize(
-            self.objective,
-            timeout=self.studytime
-        )
+        study.optimize(self.objective, timeout=self.studytime)
 
-        df = self.__analyze_study(study)
-
+        df = self._analyze_study(study)
         return study, df
 
-    def __analyze_study(self, study: optuna.study.Study) -> pd.DataFrame:
-        logger.info(f"Best parameters: {study.best_params}")
-        logger.info(f"Best score: {study.best_value}")
+    def _analyze_study(self, study: optuna.study.Study) -> pd.DataFrame:
+        logger.info("Best parameters: %s", study.best_params)
+        logger.info("Best score: %s", study.best_value)
 
         df: pd.DataFrame = study.trials_dataframe()
-        logger.info("\nTrials DataFrame:")
-        logger.info(df.sort_values("value").to_string())
+        logger.info("\nTrials DataFrame:\n%s", df.sort_values("value").to_string())
 
-        param_importances = optuna.importance.get_param_importances(study)
-        logger.info("Parameter Importances:")
-        for key, value in param_importances.items():
-            logger.info(f"{key}: {value}")
+        try:
+            param_importances = optuna.importance.get_param_importances(study)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to compute parameter importances: %s", exc)
+            param_importances = {}
+
+        if param_importances:
+            logger.info("Parameter Importances:")
+            for key, value in param_importances.items():
+                logger.info("%s: %s", key, value)
 
         df_pl = pl.from_pandas(df)
-        df_roll_mean = df_pl.sort("value").select(
-            [pl.col("value")] + 
-            [pl.col(c).rolling_mean(window_size=10).alias(f"{c}_rollmean10") for c in df.columns if c.startswith("params_")]
-        )
-        df_roll_min = df_pl.sort("value").select(
-            [pl.col("value")] + 
-            [pl.col(c).rolling_min(window_size=10).alias(f"{c}_rollmin10") for c in df.columns if c.startswith("params_")]
-        )
-        df_roll_max = df_pl.sort("value").select(
-            [pl.col("value")] + 
-            [pl.col(c).rolling_max(window_size=10).alias(f"{c}_rollmax10") for c in df.columns if c.startswith("params_")]
-        )
+        param_cols = [c for c in df.columns if c.startswith("params_")]
+        if param_cols:
+            df_roll_mean = df_pl.sort("value").select(
+                [pl.col("value")] + [pl.col(c).rolling_mean(window_size=10).alias(f"{c}_rollmean10") for c in param_cols]
+            )
+            df_roll_min = df_pl.sort("value").select(
+                [pl.col("value")] + [pl.col(c).rolling_min(window_size=10).alias(f"{c}_rollmin10") for c in param_cols]
+            )
+            df_roll_max = df_pl.sort("value").select(
+                [pl.col("value")] + [pl.col(c).rolling_max(window_size=10).alias(f"{c}_rollmax10") for c in param_cols]
+            )
 
-        logger.info(df_roll_mean.to_pandas().to_string())
-        logger.info(df_roll_min.to_pandas().to_string())
-        logger.info(df_roll_max.to_pandas().to_string())
+            logger.info(df_roll_mean.to_pandas().to_string())
+            logger.info(df_roll_min.to_pandas().to_string())
+            logger.info(df_roll_max.to_pandas().to_string())
 
         return df_pl.sort("value").to_pandas()

--- a/src/hyperparameterTuning/StratFilterSamples.py
+++ b/src/hyperparameterTuning/StratFilterSamples.py
@@ -1,28 +1,22 @@
+import logging
+from typing import Dict
+
 import numpy as np
-import polars as pl
-import pandas as pd
-import datetime
-import scipy
 import optuna
-import torch
-import random
+import polars as pl
 
 from src.hyperparameterTuning.BaseStrategy import BaseStrategy
-from src.predictionModule.LoadupSamples import LoadupSamples
-from src.predictionModule.FilterSamples import FilterSamples
-from src.predictionModule.MachineModels import MachineModels
 
-import logging
 logger = logging.getLogger(__name__)
+
 
 class StratFilterSamples(BaseStrategy):
     default_params = {
         "idxAfterPrediction": 5,
-        'timesteps': 60,
-        'target_option': 'last',
+        "timesteps": 60,
+        "target_option": "last",
         "LoadupSamples_time_scaling_stretch": True,
         "LoadupSamples_time_inc_factor": 61,
-        
         "Treetime_LSTM_days_to_train": 1000,
         "LSTM_units": 32,
         "LSTM_num_layers": 1,
@@ -40,106 +34,188 @@ class StratFilterSamples(BaseStrategy):
         "LSTM_conv1d": True,
         "LSTM_conv1d_kernel_size": 3,
         "LSTM_loss": "mse",
-    
         "FilterSamples_q_up": 0.985,
         "FilterSamples_days_to_train_end": 115,
         "FilterSamples_cat_over20": True,
         "FilterSamples_cat_posOneYearReturn": False,
         "FilterSamples_cat_posFiveYearReturn": False,
-        
         "FilterSamples_lincomb_epochs": 5,
         "FilterSamples_lincomb_show_progress": False,
         "FilterSamples_lincomb_featureratio": 0.5,
         "FilterSamples_lincomb_itermax": 1,
-        "FilterSamples_lincomb_init_toprand":  3,
+        "FilterSamples_lincomb_init_toprand": 3,
         "FilterSamples_lincomb_batch_size": 2**12,
-    
         "FilterSamples_taylor_horizon_days": 50,
         "FilterSamples_taylor_roll_window_days": 10,
-        "FilterSamples_taylor_weight_slope": 1.268923
+        "FilterSamples_taylor_weight_slope": 1.268923,
     }
 
-    def __init__(self, filter_method):
+    def __init__(self, filter_method: str) -> None:
+        if filter_method not in {"lincomb", "taylor"}:
+            raise ValueError("filter_method must be either 'lincomb' or 'taylor'.")
         self.filter_method = filter_method
 
+    # ------------------------------------------------------------------
+    # Optuna hooks
+    # ------------------------------------------------------------------
     def sample_params(self, trial: optuna.Trial) -> dict:
-        LINCOMB_SPACE = {
+        lincomb_space = {
             "FilterSamples_days_to_train_end": ("int", 250, 350, {"step": 10}),
             "FilterSamples_lincomb_lr": ("float", 1e-4, 5e-3, {"log": False}),
             "FilterSamples_lincomb_epochs": ("int", 10, 200, {"step": 10}),
             "FilterSamples_lincomb_probs_noise_std": ("float", 0.1, 0.3, {"log": False}),
             "FilterSamples_lincomb_subsample_ratio": ("float", 0.2, 0.4, {}),
             "FilterSamples_lincomb_sharpness": ("float", 2.0, 5.0, {"log": False}),
-            #"FilterSamples_lincomb_featureratio": ("float", 0.05, 0.99, {"log": True}),
-            #"FilterSamples_lincomb_itermax": ("int", 1, 3, {}),
-            "FilterSamples_lincomb_init_toprand": ("int", 2, 15, {})
+            "FilterSamples_lincomb_init_toprand": ("int", 2, 15, {}),
         }
-        TAYLOR_SPACE = {
+        taylor_space = {
             "FilterSamples_days_to_train_end": ("int", 19, 48, {"step": 1}),
             "FilterSamples_taylor_horizon_days": ("int", 24, 28, {"step": 2}),
             "FilterSamples_taylor_roll_window_days": ("int", 1, 6, {"step": 1}),
-            "FilterSamples_taylor_weight_slope": ("float", 1.5, 3.5, {"log": False})
+            "FilterSamples_taylor_weight_slope": ("float", 1.5, 3.5, {"log": False}),
         }
 
-        PARAMS = self.default_params.copy()
-        if self.filter_method == 'lincomb':
-            PARAMS.update(self.__parse_params(trial, LINCOMB_SPACE))
+        params = dict(self.default_params)
+        if self.filter_method == "lincomb":
+            params.update(self._parse_params(trial, lincomb_space))
+        else:
+            params.update(self._parse_params(trial, taylor_space))
+        return params
 
-        elif self.filter_method == 'taylor':
-            PARAMS.update(self.__parse_params(trial, TAYLOR_SPACE))
+    def score(
+        self,
+        Xtr_tree,
+        Xtr_time,
+        ytr_tree,
+        Xte_tree,
+        Xte_time,
+        yte_tree,
+        params: dict,
+    ) -> float:
+        mask_train_pre = self._ensure_mask(params.get("pre_mask_train"), Xtr_tree)
+        mask_test_pre = self._ensure_mask(params.get("pre_mask_test"), Xte_tree)
+        treenames = params.get("treenames")
+        meta_train = params.get("meta_train")
+        meta_test = params.get("meta_test")
+        mm = params.get("mm") or params.get("model_machine")
 
-        return PARAMS
+        if treenames is None or meta_train is None:
+            raise ValueError("Tree feature names and meta_train must be provided.")
+        if mm is None or not hasattr(mm, "params"):
+            raise ValueError("A MachineModels-like object with 'params' must be supplied.")
 
-    def __parse_params(self, trial, space):
+        meta_train_filtered = meta_train.filter(pl.Series(mask_train_pre))
+        if meta_test is None:
+            meta_test = meta_train
+        meta_test_filtered = meta_test.filter(pl.Series(mask_test_pre))
+
+        y_test = yte_tree[mask_test_pre] if yte_tree is not None else ytr_tree[mask_test_pre]
+
+        from src.predictionModule.FilterSamples import FilterSamples
+
+        fs = FilterSamples(
+            Xtree_train=Xtr_tree[mask_train_pre],
+            ytree_train=ytr_tree[mask_train_pre],
+            treenames=treenames,
+            Xtree_test=Xte_tree[mask_test_pre],
+            ytree_test=y_test,
+            meta_train=meta_train_filtered,
+            meta_test=meta_test_filtered,
+            params=mm.params,
+        )
+
+        if self.filter_method == "lincomb":
+            mask_train, mask_test = fs.lincomb_masks()
+        else:
+            mask_train, mask_test = fs.taylor_feature_masks()
+
+        score_train = fs.evaluate_mask(
+            mask_train,
+            meta_train_filtered["date"],
+            ytr_tree[mask_train_pre],
+        )
+        score_test = fs.evaluate_mask(
+            mask_test,
+            meta_test_filtered["date"],
+            y_test,
+        )
+
+        logger.info("  Score (train) = %s", score_train)
+        logger.info("  Score (test)  = %s", score_test)
+
+        return float(score_test)
+
+    def mask_precompute(
+        self,
+        Xtr_tree,
+        Xtr_time,
+        ytr_tree,
+        Xte_tree,
+        Xte_time,
+        yte_tree,
+        params: dict,
+    ) -> Dict[str, np.ndarray]:
+        treenames = params.get("treenames")
+        meta_train = params.get("meta_train")
+        meta_test = params.get("meta_test")
+        mm = params.get("mm") or params.get("model_machine")
+
+        if treenames is None or meta_train is None or mm is None or not hasattr(mm, "params"):
+            raise ValueError("treenames, meta_train and a MachineModels instance are required.")
+
+        if meta_test is None:
+            meta_test = meta_train
+
+        cat_mask_train = np.ones(Xtr_tree.shape[0], dtype=bool)
+        cat_mask_test = np.ones(Xte_tree.shape[0], dtype=bool)
+
+        from src.predictionModule.FilterSamples import FilterSamples
+
+        fs = FilterSamples(
+            Xtree_train=Xtr_tree,
+            ytree_train=ytr_tree,
+            treenames=treenames,
+            Xtree_test=Xte_tree,
+            ytree_test=yte_tree,
+            meta_train=meta_train,
+            meta_test=meta_test,
+            params=mm.params,
+        )
+
+        cat_train, cat_test = fs.categorical_masks()
+        cat_mask_train &= cat_train
+        if cat_test is not None:
+            cat_mask_test &= cat_test
+
+        recent_mask = fs.get_recent_training_mask(mm.params.get("FilterSamples_days_to_train_end"))
+        mask_train_pre = cat_mask_train & recent_mask
+        mask_test_pre = cat_mask_test
+
+        logger.info(
+            "  Pre-masks -> train kept: %.2f%% | test kept: %.2f%%",
+            100 * mask_train_pre.mean(),
+            100 * mask_test_pre.mean(),
+        )
+
+        return {
+            "pre_mask_train": mask_train_pre,
+            "pre_mask_test": mask_test_pre,
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_params(trial: optuna.Trial, space: dict) -> dict:
         out = {}
         for name, spec in space.items():
             kind, lo, hi, kw = spec
-            sug = trial.suggest_int if kind == "int" else trial.suggest_float
-            out[name] = sug(name.replace("FilterSamples_", ""), lo, hi, **kw)
+            suggest = trial.suggest_int if kind == "int" else trial.suggest_float
+            out[name] = suggest(name.replace("FilterSamples_", ""), lo, hi, **kw)
         return out
-    
-    def score(self, 
-            Xtr_tree,
-            Xtr_time, 
-            ytr_tree, 
-            Xte_tree,
-            Xte_time, 
-            yte_tree,
-            params: dict
-        ) -> float | None:
-        mask_train_pre: np.ndarray   = params.get("pre_mask_train", None)
-        mask_test_pre: np.ndarray    = params.get("pre_mask_test", None)
-        treenames: list[str]         = params.get("treenames", None)
-        mm: MachineModels            = params.get("model_machine", None)
-        meta_train: pl.DataFrame     = params.get("meta_train", None)
-        meta_test: pl.DataFrame      = params.get("meta_test", None)
 
-        if (mask_train_pre is None 
-            or mask_test_pre is None
-            or mm is None
-            or treenames is None
-            or meta_train is None
-            or meta_test is None):
-            raise ValueError("All score information must be provided in params.")
-
-        fs = FilterSamples(
-            Xtree_train = Xtr_tree[mask_train_pre], 
-            ytree_train = ytr_tree[mask_train_pre], 
-            treenames   = treenames,
-            Xtree_test  = Xte_tree[mask_test_pre],
-            ytree_test  = yte_tree[mask_test_pre],
-            meta_train  = meta_train[mask_train_pre],
-            meta_test   = meta_test[mask_test_pre],
-            params      = mm.params,
-        )
-        if self.filter_method == 'lincomb':
-            mask_train, mask_test = FilterSamples.lincomb_masks(fs)
-        elif self.filter_method == 'taylor':
-            mask_train, mask_test = FilterSamples.taylor_feature_masks(fs)
-
-        score_train = fs.evaluate_mask(mask_train, meta_train['date'].filter(pl.Series(mask_train_pre)), ytr_tree[mask_train_pre])
-        score_test  = fs.evaluate_mask(mask_test,  meta_test['date'].filter(pl.Series(mask_test_pre)),  yte_tree[mask_test_pre])
-        logger.info(f"  Score (train) = {score_train}")
-        logger.info(f"  Score (test)  = {score_test}")
-
-        return score_test
+    @staticmethod
+    def _ensure_mask(mask, array) -> np.ndarray:
+        if mask is None:
+            return np.ones(array.shape[0], dtype=bool)
+        return np.asarray(mask, dtype=bool)

--- a/unittests/hyperparameterTuning/test_optuna.py
+++ b/unittests/hyperparameterTuning/test_optuna.py
@@ -1,0 +1,207 @@
+import datetime
+import random
+import sys
+import types
+from types import SimpleNamespace
+
+import numpy as np
+import optuna
+import polars as pl
+import pytest
+
+from src.hyperparameterTuning.OptunaClient import OptunaClient
+from src.hyperparameterTuning.StratFilterSamples import StratFilterSamples
+
+
+def _business_days(start: datetime.date, count: int) -> list[datetime.date]:
+    days: list[datetime.date] = []
+    current = start
+    while len(days) < count:
+        if current.weekday() < 5:
+            days.append(current)
+        current += datetime.timedelta(days=1)
+    return days
+
+
+def _dummy_loadup_samples(n_samples: int = 40) -> SimpleNamespace:
+    rng = np.random.default_rng(42)
+    dates = _business_days(datetime.date(2020, 1, 1), n_samples)
+    closes = np.linspace(10.0, 20.0, n_samples)
+    adj_closes = closes + 0.5
+
+    meta = pl.DataFrame(
+        {
+            "date": dates,
+            "Close": closes,
+            "AdjClose": adj_closes,
+            "Open": closes + 0.2,
+            "ticker": ["AAA"] * n_samples,
+        }
+    )
+
+    return SimpleNamespace(
+        train_Xtree=rng.normal(size=(n_samples, 3)),
+        train_ytree=rng.uniform(0.8, 1.2, size=n_samples),
+        train_Xtime=None,
+        train_ytime=None,
+        featureTreeNames=["f1", "f2", "f3"],
+        featureTimeNames=[],
+        meta_pl_train=meta,
+    )
+
+
+class _DummyStrategy:
+    def __init__(self):
+        self.calls = 0
+
+    def sample_params(self, trial: optuna.Trial) -> dict:
+        return {}
+
+    def mask_precompute(self, *args, **kwargs):
+        Xtr_tree = args[0]
+        Xte_tree = args[3]
+        return {
+            "pre_mask_train": np.ones(Xtr_tree.shape[0], dtype=bool),
+            "pre_mask_test": np.ones(Xte_tree.shape[0], dtype=bool),
+        }
+
+    def score(self, *args, **kwargs) -> float:
+        self.calls += 1
+        yte_tree = args[5]
+        return float(np.mean(yte_tree))
+
+
+class _DummyModel:
+    def __init__(self, params: dict):
+        self.params = params
+
+
+class _FakeFilterSamples:
+    def __init__(self, Xtree_train, ytree_train, treenames, Xtree_test, ytree_test, meta_train, meta_test, params):
+        self.Xtree_train = Xtree_train
+        self.ytree_train = ytree_train
+        self.Xtree_test = Xtree_test
+        self.ytree_test = ytree_test
+        self.meta_train = meta_train
+        self.meta_test = meta_test
+        self.params = params
+
+    def categorical_masks(self):
+        return np.ones(self.Xtree_train.shape[0], dtype=bool), np.ones(self.Xtree_test.shape[0], dtype=bool)
+
+    def get_recent_training_mask(self, *_):
+        return np.ones(self.Xtree_train.shape[0], dtype=bool)
+
+    def lincomb_masks(self):
+        return np.ones(self.Xtree_train.shape[0], dtype=bool), np.ones(self.Xtree_test.shape[0], dtype=bool)
+
+    def taylor_feature_masks(self):
+        return self.lincomb_masks()
+
+    def evaluate_mask(self, mask, dates, y):
+        mask = np.asarray(mask, dtype=bool)
+        return float(np.mean(y[mask]))
+
+
+def test_optuna_client_get_slices() -> None:
+    ls = _dummy_loadup_samples()
+    client = OptunaClient(
+        ls=ls,
+        n_splits=5,
+        n_test_days=3,
+        n_training_days=10,
+        rng=random.Random(0),
+        model_cls=_DummyModel,
+    )
+
+    slices = client.get_slices()
+    assert len(slices) == 5
+    for train_slice, test_slice in slices:
+        assert train_slice.stop - train_slice.start > 0
+        assert test_slice.stop - test_slice.start > 0
+        assert train_slice.stop <= test_slice.start
+
+
+def test_optuna_client_objective_uses_strategy() -> None:
+    ls = _dummy_loadup_samples()
+    client = OptunaClient(
+        ls=ls,
+        n_splits=3,
+        n_test_days=2,
+        n_training_days=8,
+        rng=random.Random(1),
+        model_cls=_DummyModel,
+    )
+    strategy = _DummyStrategy()
+    objective = client.make_objective(strategy=strategy)
+
+    result = objective(optuna.trial.FixedTrial({}))
+    assert strategy.calls == 3
+    assert np.isfinite(result)
+
+
+def test_strat_filter_samples_mask_precompute_shapes(monkeypatch) -> None:
+    ls = _dummy_loadup_samples()
+    strategy = StratFilterSamples(filter_method="lincomb")
+    dummy_model = _DummyModel({"FilterSamples_days_to_train_end": 30})
+
+    fake_module = types.ModuleType("FilterSamples")
+    fake_module.FilterSamples = _FakeFilterSamples
+    monkeypatch.setitem(sys.modules, "src.predictionModule.FilterSamples", fake_module)
+
+    params = {
+        "mm": dummy_model,
+        "treenames": ls.featureTreeNames,
+        "meta_train": ls.meta_pl_train,
+    }
+
+    masks = strategy.mask_precompute(
+        ls.train_Xtree,
+        ls.train_Xtime,
+        ls.train_ytree,
+        ls.train_Xtree,
+        ls.train_Xtime,
+        ls.train_ytree,
+        params=params,
+    )
+
+    assert masks["pre_mask_train"].shape[0] == ls.train_Xtree.shape[0]
+    assert masks["pre_mask_test"].shape[0] == ls.train_Xtree.shape[0]
+
+
+def test_strat_filter_samples_score_with_stub(monkeypatch) -> None:
+    ls = _dummy_loadup_samples(20)
+    strategy = StratFilterSamples(filter_method="lincomb")
+    dummy_model = _DummyModel({"FilterSamples_days_to_train_end": 10})
+
+    fake_module = types.ModuleType("FilterSamples")
+    fake_module.FilterSamples = _FakeFilterSamples
+    monkeypatch.setitem(sys.modules, "src.predictionModule.FilterSamples", fake_module)
+
+    base_params = {
+        "mm": dummy_model,
+        "treenames": ls.featureTreeNames,
+        "meta_train": ls.meta_pl_train,
+    }
+    mask_params = strategy.mask_precompute(
+        ls.train_Xtree,
+        ls.train_Xtime,
+        ls.train_ytree,
+        ls.train_Xtree,
+        ls.train_Xtime,
+        ls.train_ytree,
+        params=base_params,
+    )
+
+    score = strategy.score(
+        ls.train_Xtree,
+        ls.train_Xtime,
+        ls.train_ytree,
+        ls.train_Xtree,
+        ls.train_Xtime,
+        ls.train_ytree,
+        params={**base_params, **mask_params},
+    )
+
+    expected = float(np.mean(ls.train_ytree))
+    assert score == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- rewrite the Optuna client, tuning driver and strategy scaffold to support reusable mask precomputation, deterministic cross-validation splits and graceful logging
- update the Optuna execution script to wire the new abstractions and emit persisted study results
- add focused unit tests that exercise the Optuna client and strategy workflow with lightweight stubs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2ace07dd88325a4e9fab460b82977